### PR TITLE
Adding Python 3.4 support and notes on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,6 @@ env:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-addons:
-  apt:
-    sources:
-      - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-      - shellcheck
-
 matrix:
   include:
     - env:

--- a/SupportFiles/chain-load.sh
+++ b/SupportFiles/chain-load.sh
@@ -35,6 +35,23 @@ quiet_git() {
    fi
 }
 
+
+# Install Python 2.x, pip, and virtualenv
+yum install -y python python2-pip
+pip2 install -U virtualenv pip
+
+# Install Python3.4, pip, and virtualenv
+yum install -y python34 
+curl https://bootstrap.pypa.io/get-pip.py | python3.4  # no rpm in epel
+pip3.4 install -U virtualenv pip
+
+
+# Install Python 3.6, pip, and virtualenv using the semi-official "Inline with Upstream Stable" repo
+# yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+# yum install -y python36u python36u-pip
+# pip3.6 install -U virtualenv pip
+
+
 # Create git staging-area as needed
 if [[ -d ${SCRIPTHOME}/git ]]
 then

--- a/SupportFiles/jenkins-agent_userscript.sh
+++ b/SupportFiles/jenkins-agent_userscript.sh
@@ -51,6 +51,23 @@ printf 'Pulling agent.jar from %s' "${JENKMSTR}"
 curl -OskL https://"${JENKMSTR}"/jnlpJars/agent.jar && echo || \
   err_exit "Failed to pull agent.jar"
 
+
+# Install Python 2.x, pip, and virtualenv
+yum install -y python python2-pip
+pip2 install -U virtualenv pip
+
+# Install Python3.4, pip, and virtualenv
+yum install -y python34 
+curl https://bootstrap.pypa.io/get-pip.py | python3.4  # no rpm in epel
+pip3.4 install -U virtualenv pip
+
+
+# Install Python 3.6, pip, and virtualenv using the semi-official "Inline with Upstream Stable" repo
+yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+yum install -y python36u python36u-pip
+pip3.6 install -U virtualenv pip
+
+
 # Install the OWASP-ZAP agent-software
 if [[ -f ${ZAPARCHIVE} ]]
 then

--- a/SupportFiles/jenkins-agent_userscript.sh
+++ b/SupportFiles/jenkins-agent_userscript.sh
@@ -63,9 +63,9 @@ pip3.4 install -U virtualenv pip
 
 
 # Install Python 3.6, pip, and virtualenv using the semi-official "Inline with Upstream Stable" repo
-yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-yum install -y python36u python36u-pip
-pip3.6 install -U virtualenv pip
+# yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+# yum install -y python36u python36u-pip
+# pip3.6 install -U virtualenv pip
 
 
 # Install the OWASP-ZAP agent-software

--- a/SupportFiles/jenkins-agent_userscript.sh
+++ b/SupportFiles/jenkins-agent_userscript.sh
@@ -52,21 +52,6 @@ curl -OskL https://"${JENKMSTR}"/jnlpJars/agent.jar && echo || \
   err_exit "Failed to pull agent.jar"
 
 
-# Install Python 2.x, pip, and virtualenv
-yum install -y python python2-pip
-pip2 install -U virtualenv pip
-
-# Install Python3.4, pip, and virtualenv
-yum install -y python34 
-curl https://bootstrap.pypa.io/get-pip.py | python3.4  # no rpm in epel
-pip3.4 install -U virtualenv pip
-
-
-# Install Python 3.6, pip, and virtualenv using the semi-official "Inline with Upstream Stable" repo
-# yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-# yum install -y python36u python36u-pip
-# pip3.6 install -U virtualenv pip
-
 
 # Install the OWASP-ZAP agent-software
 if [[ -f ${ZAPARCHIVE} ]]


### PR DESCRIPTION

Simply install the yum packages, pip, and then pip update itself and virtualenv for both Python 2.7 and 3.4.

Installation for Python 3.6 is documented, but relies on the semi-official IUS rpm repo.  Steps are commented out to avoid that dependency until it is specifically requested.