### PR TITLE
Split Up Upgrade Tasks

### DIFF
--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -24,7 +24,6 @@ pipeline {
     parameters {
         string(name: 'AwsRegion', defaultValue: 'us-east-1', description: 'Amazon region to deploy resources into')
         string(name: 'AwsCred', description: 'Jenkins-stored AWS credential with which to execute cloud-layer commands')
-        string(name: 'GitCred', description: 'Jenkins-stored Git credential with which to execute git commands')
         string(name: 'SourceBucket', description: 'Bucket to copy contents from')
         string(name: 'DestinationBucket', description: 'Bucket to copy contents to')
         string(name: 'RootFolder', description: 'Which bucket-folder to synchronize (if any)')
@@ -35,19 +34,26 @@ pipeline {
             steps {
                 withCredentials(
                     [
-                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
-                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
                     ]
                 ) {
                     sh '''#!/bin/bash
                         if [[ -z ${RootFolder} ]]
                         then
+                           echo "Censusing entirety of s3://${SourceBucket}"
+                        else
                            LIMITSCOPE="--prefix ${RootFolder}"
+                           echo "Censusing s3://${SourceBucket}/${RootFolder}"
                         fi
 
-                        aws s3api list-objects --bucket ${SourceBucket} \${LIMITSCOPE} --output json \
-                          --query "[sum(Contents[].Size), length(Contents[])]" | \
-                          awk 'NR!=2 {print $0;next} NR==2 {print $0/1024/1024/1024" GB"}'
+                        BUCKETCOUNTS=($( aws s3api list-objects --bucket ${SourceBucket} \${LIMITSCOPE} --output json --query "[sum(Contents[].Size), length(Contents[])]" | awk 'NR!=2 {print \$0;next} NR==2 {print \$0 / 1024 / 1024 / 1024}' ))
+
+                        # For the console readers...
+                        printf "\tBucket Size: %sGiB\n" "${BUCKETCOUNTS[1]}"
+                        printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
+
+                        # Save for later use
+                        echo "SourceBucket ${BUCKETCOUNTS[@1]}" > bucket_census.txt
 
                     '''
                 }
@@ -57,28 +63,24 @@ pipeline {
             steps {
                 withCredentials(
                     [
-                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
-                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
                     ]
                 ) {
                     sh '''#!/bin/bash
                         echo > /dev/null
-
                     '''
                 }
             }
         }
-        stage ('Copy Bucket') {
+        stage ('Diff Buckets') {
             steps {
                 withCredentials(
                     [
-                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
-                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
                     ]
                 ) {
                     sh '''#!/bin/bash
                         echo > /dev/null
-
                     '''
                 }
             }

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -67,10 +67,11 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
+                        cat bucket_census.txt
                         printf "Syncing from s3://${SourceBucket}/${RootFolder} "
                         printf "to s3://${DestinationBucket}/${RootFolder} "
                         echo "[BE PATIENT]"
-                        aws s3 sync "s3://${SourceBucket}/${RootFolder}" "s3://${DestinationBucket}/${RootFolder}"
+                        aws s3 sync --delete "s3://${SourceBucket}/${RootFolder}" "s3://${DestinationBucket}/${RootFolder}"
 
                         SYNCSTATUS="$?"
 

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -30,7 +30,7 @@ pipeline {
     }
 
     stages {
-        stage ('Census Sourc Bucket') {
+        stage ('Census Source Bucket') {
             steps {
                 withCredentials(
                     [
@@ -97,9 +97,42 @@ pipeline {
                         [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
                     ]
                 ) {
-                    sh '''#!/bin/bash
-                        echo > /dev/null
-                    '''
+                    parallel (
+                        source: {
+                            sh '''#!/bin/bash
+                                if [[ -z ${RootFolder} ]]
+                                then
+                                   echo "Censusing entirety of s3://${SourceBucket}"
+                                else
+                                   LIMITSCOPE="--prefix ${RootFolder}"
+                                   echo "Censusing s3://${SourceBucket}/${RootFolder}"
+                                fi
+        
+                                BUCKETCOUNTS=($( aws s3api list-objects --bucket ${SourceBucket} \${LIMITSCOPE} --output json --query "[sum(Contents[].Size), length(Contents[])]" | awk 'NR!=2 {print \$0;next} NR==2 {print \$0 / 1024 / 1024 / 1024}' ))
+        
+                                # For the console readers...
+                                printf "\tBucket Size: %sGiB\n" "${BUCKETCOUNTS[1]}"
+                                printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
+                            '''
+                        },
+                        destination: {
+                            sh '''#!/bin/bash
+                                if [[ -z ${RootFolder} ]]
+                                then
+                                   echo "Censusing entirety of s3://${DestinationBucket}"
+                                else
+                                   LIMITSCOPE="--prefix ${RootFolder}"
+                                   echo "Censusing s3://${DestinationBucket}/${RootFolder}"
+                                fi
+        
+                                BUCKETCOUNTS=($( aws s3api list-objects --bucket ${DestinationBucket} \${LIMITSCOPE} --output json --query "[sum(Contents[].Size), length(Contents[])]" | awk 'NR!=2 {print \$0;next} NR==2 {print \$0 / 1024 / 1024 / 1024}' ))
+        
+                                # For the console readers...
+                                printf "\tBucket Size: %sGiB\n" "${BUCKETCOUNTS[1]}"
+                                printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
+                            '''
+                        }
+                    )
                 }
             }
         }

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -30,35 +30,6 @@ pipeline {
     }
 
     stages {
-        stage ('Census Source Bucket') {
-            steps {
-                withCredentials(
-                    [
-                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                    ]
-                ) {
-                    sh '''#!/bin/bash
-                        if [[ -z ${RootFolder} ]]
-                        then
-                           echo "Censusing entirety of s3://${SourceBucket}"
-                        else
-                           LIMITSCOPE="--prefix ${RootFolder}"
-                           echo "Censusing s3://${SourceBucket}/${RootFolder}"
-                        fi
-
-                        BUCKETCOUNTS=($( aws s3api list-objects --bucket ${SourceBucket} \${LIMITSCOPE} --output json --query "[sum(Contents[].Size), length(Contents[])]" | awk 'NR!=2 {print \$0;next} NR==2 {print \$0 / 1024 / 1024 / 1024}' ))
-
-                        # For the console readers...
-                        printf "\tBucket Size: %sGiB\n" "${BUCKETCOUNTS[1]}"
-                        printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
-
-                        # Save for later use
-                        echo "SourceBucket ${BUCKETCOUNTS[@]}" > bucket_census.txt
-
-                    '''
-                }
-            }
-        }
         stage ('Copy Bucket') {
             steps {
                 input 'Have you turned of cron on the source node'

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -61,6 +61,7 @@ pipeline {
         }
         stage ('Copy Bucket') {
             steps {
+                input 'Have you turned of cron on the source node'
                 withCredentials(
                     [
                         [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -53,7 +53,7 @@ pipeline {
                         printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
 
                         # Save for later use
-                        echo "SourceBucket ${BUCKETCOUNTS[@1]}" > bucket_census.txt
+                        echo "SourceBucket ${BUCKETCOUNTS[@]}" > bucket_census.txt
 
                     '''
                 }
@@ -67,7 +67,24 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo > /dev/null
+                        printf "Syncing from s3://${SourceBucket}/${RootFolder} "
+                        printf "to s3://${DestinationBucket}/${RootFolder} "
+                        echo "[BE PATIENT]"
+                        aws s3 sync "s3://${SourceBucket}/${RootFolder}" "s3://${DestinationBucket}/${RootFolder}"
+
+                        SYNCSTATUS="$?"
+
+                        case ${SYNCSTATUS} in
+                           0) echo "No errors recorded"
+                              ;;
+                           1) echo "Some files were omitted"
+                              exit 0
+                              ;;
+                           2) echo "Error messages were emitted"
+                              ;;
+                        esac
+
+                        exit "${SYNCSTATUS}"
                     '''
                 }
             }

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -1,0 +1,87 @@
+pipeline {
+
+    agent any
+
+    options {
+        buildDiscarder(
+            logRotator(
+                numToKeepStr: '5',
+                daysToKeepStr: '30',
+                artifactDaysToKeepStr: '30',
+                artifactNumToKeepStr: '3'
+            )
+        )
+        disableConcurrentBuilds()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    environment {
+        AWS_DEFAULT_REGION = "${AwsRegion}"
+        AWS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+        REQUESTS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+    }
+
+    parameters {
+        string(name: 'AwsRegion', defaultValue: 'us-east-1', description: 'Amazon region to deploy resources into')
+        string(name: 'AwsCred', description: 'Jenkins-stored AWS credential with which to execute cloud-layer commands')
+        string(name: 'GitCred', description: 'Jenkins-stored Git credential with which to execute git commands')
+        string(name: 'SourceBucket', description: 'Bucket to copy contents from')
+        string(name: 'DestinationBucket', description: 'Bucket to copy contents to')
+        string(name: 'RootFolder', description: 'Which bucket-folder to synchronize (if any)')
+    }
+
+    stages {
+        stage ('Census Sourc Bucket') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        if [[ -z ${RootFolder} ]]
+                        then
+                           LIMITSCOPE="--prefix ${RootFolder}"
+                        fi
+
+                        aws s3api list-objects --bucket ${SourceBucket} \${LIMITSCOPE} --output json \
+                          --query "[sum(Contents[].Size), length(Contents[])]" | \
+                          awk 'NR!=2 {print $0;next} NR==2 {print $0/1024/1024/1024" GB"}'
+
+                    '''
+                }
+            }
+        }
+        stage ('Copy Bucket') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo > /dev/null
+
+                    '''
+                }
+            }
+        }
+        stage ('Copy Bucket') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo > /dev/null
+
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
+++ b/Deployment/Jenkins/master/Jenkins_S3-MigrationHelper.groovy
@@ -92,13 +92,13 @@ pipeline {
         }
         stage ('Diff Buckets') {
             steps {
-                withCredentials(
-                    [
-                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
-                    ]
-                ) {
-                    parallel (
-                        source: {
+                parallel (
+                    source: {
+                        withCredentials(
+                            [
+                                [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                            ]
+                        ) {
                             sh '''#!/bin/bash
                                 if [[ -z ${RootFolder} ]]
                                 then
@@ -114,8 +114,14 @@ pipeline {
                                 printf "\tBucket Size: %sGiB\n" "${BUCKETCOUNTS[1]}"
                                 printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
                             '''
-                        },
-                        destination: {
+                        }
+                    },
+                    destination: {
+                        withCredentials(
+                            [
+                                [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                            ]
+                        ) {
                             sh '''#!/bin/bash
                                 if [[ -z ${RootFolder} ]]
                                 then
@@ -132,8 +138,8 @@ pipeline {
                                 printf "\tBucket objects: %s\n" "${BUCKETCOUNTS[2]}"
                             '''
                         }
-                    )
-                }
+                    }
+                )
             }
         }
     }

--- a/Deployment/Jenkins/master/Jenkins_master_infra.groovy
+++ b/Deployment/Jenkins/master/Jenkins_master_infra.groovy
@@ -1,0 +1,125 @@
+pipeline {
+
+    agent any
+
+    options {
+        buildDiscarder(
+            logRotator(
+                numToKeepStr: '5',
+                daysToKeepStr: '30',
+                artifactDaysToKeepStr: '30',
+                artifactNumToKeepStr: '3'
+            )
+        )
+        disableConcurrentBuilds()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    environment {
+        AWS_DEFAULT_REGION = "${AwsRegion}"
+        AWS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+        REQUESTS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+    }
+
+    parameters {
+        string(name: 'AwsRegion', defaultValue: 'us-east-1', description: 'Amazon region to deploy resources into')
+        string(name: 'AwsCred', description: 'Jenkins-stored AWS credential with which to execute cloud-layer commands')
+        string(name: 'GitCred', description: 'Jenkins-stored Git credential with which to execute git commands')
+        string(name: 'GitProjUrl', description: 'SSH URL from which to download the Jenkins git project')
+        string(name: 'GitProjBranch', description: 'Project-branch to use from the Jenkins git project')
+        string(name: 'CfnStackRoot', description: 'Unique token to prepend to all stack-element names')
+        string(name: 'BucketTemplate', description: 'link to bucket template')
+        string(name: 'IamRoleTemplate', description: 'Link to IAM template')
+        string(name: 'SecurityGroupTemplate', description: 'Link to SG template')
+        string(name: 'ServiceTld', defaultValue: 'amazonaws.com', description: 'TLD of the IAMable service-name')
+        string(name: 'JenkinsBackupBucket', description: '(Optional: will be randomly named if left un-set) Name to give to S3 Bucket used for longer-term retention of backups')
+        string(name: 'RolePrefix', description: '(Optional) Prefix to apply to IAM role')
+        string(name: 'TargetVPC', description: 'ID of the VPC to deploy cluster nodes into')
+        string(name: 'JenkinsAgentPort', defaultValue: '', description: 'TCP Port number that the Jenkins agent-hosts connect through')
+    }
+
+    stages {
+        stage ('Prepare Agent Environment') {
+            steps {
+                deleteDir()
+                git branch: "${GitProjBranch}",
+                    credentialsId: "${GitCred}",
+                    url: "${GitProjUrl}"
+                writeFile file: 'service-infra.parms.json',
+                    text: /
+                    [
+                        {
+                            "ParameterKey": "BucketTemplate",
+                            "ParameterValue": "${env.BucketTemplate}"
+                        },
+                        {
+                            "ParameterKey": "IamRoleTemplate",
+                            "ParameterValue": "${env.IamRoleTemplate}"
+                        },
+                        {
+                            "ParameterKey": "SecurityGroupTemplate",
+                            "ParameterValue": "${env.SecurityGroupTemplate}"
+                        },
+                        {
+                            "ParameterKey": "JenkinsAgentPort",
+                            "ParameterValue": "${env.JenkinsAgentPort}"
+                        },
+                        {
+                            "ParameterKey": "JenkinsBackupBucket",
+                            "ParameterValue": "${env.JenkinsBackupBucket}"
+                        },
+                        {
+                            "ParameterKey": "RolePrefix",
+                            "ParameterValue": "${env.RolePrefix}"
+                        },
+                        {
+                            "ParameterKey": "TargetVPC",
+                            "ParameterValue": "${env.TargetVPC}"
+                        },
+                        {
+                            "ParameterKey": "ServiceTld",
+                            "ParameterValue": "${env.ServiceTld}"
+                        }
+                    ]
+                   /
+                }
+            }
+        stage ('Prepare AWS Environment') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo "Attempting to delete any active ${CfnStackRoot}-Infra-${BUILD_NUMBER} stacks... "
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Infra-${BUILD_NUMBER}"
+
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Infra-${BUILD_NUMBER} --region ${AwsRegion}
+                    '''
+                }
+            }
+        }
+        stage ('Launch Jenkins Master Parent Instance Stack') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY'],
+                        sshUserPrivateKey(credentialsId: "${GitCred}", keyFileVariable: 'SSH_KEY_FILE', passphraseVariable: 'SSH_KEY_PASS', usernameVariable: 'SSH_KEY_USER')
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo "Attempting to create stack ${CfnStackRoot}-Infra-${BUILD_NUMBER}..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Infra-${BUILD_NUMBER}" \
+                          --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
+                          --template-body file://Templates/make_jenkins_infra.tmplt.json \
+                          --parameters file://service-infra.parms.json
+
+                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Infra-${BUILD_NUMBER} --region ${AwsRegion}
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/Templates/make_jenkins_EC2-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-autoscale.tmplt.json
@@ -508,7 +508,7 @@
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": { "Ref": "DesiredCapacity" },
-          "Timeout": "PT30M"
+          "Timeout": "PT60M"
         }
       },
       "Properties": {
@@ -538,7 +538,7 @@
         "AutoScalingRollingUpdate": {
           "MaxBatchSize": "2",
           "MinInstancesInService": "1",
-          "PauseTime": "PT30M",
+          "PauseTime": "PT60M",
           "WaitOnResourceSignals": "true"
         }
       }

--- a/Templates/make_jenkins_EC2-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-instance.tmplt.json
@@ -376,7 +376,7 @@
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": "1",
-          "Timeout": "PT30M"
+          "Timeout": "PT60M"
         }
       },
       "Metadata": {

--- a/Templates/make_jenkins_infra.tmplt.json
+++ b/Templates/make_jenkins_infra.tmplt.json
@@ -1,6 +1,6 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
-  "Description": "This template coordinates the running of the Jenkins SecurityGroup, S3, IAM, EC2 and ELB templates.",
+  "Description": "This template coordinates the running of the Jenkins SecurityGroup, S3, and IAM templates.",
   "Metadata": {
     "AWS::CloudFormation::Interface": {
       "ParameterGroups": [

--- a/Templates/make_jenkins_infra.tmplt.json
+++ b/Templates/make_jenkins_infra.tmplt.json
@@ -1,0 +1,158 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "This template coordinates the running of the Jenkins SecurityGroup, S3, IAM, EC2 and ELB templates.",
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "Child Templates"
+          },
+          "Parameters": [
+            "SecurityGroupTemplate",
+            "BucketTemplate",
+            "IamRoleTemplate"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Jenkins Setup"
+          },
+          "Parameters": [
+            "JenkinsBackupBucket"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Miscellaneous"
+          },
+          "Parameters": [
+            "ServiceTld",
+            "TargetVPC",
+            "RolePrefix"
+          ]
+        }
+      ]
+    }
+  },
+  "Outputs": {
+    "JenkinsAppSg": {
+      "Description": "Application-access Security Group",
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-AppSg"}
+      },
+      "Value": { "Fn::GetAtt": [ "SgRes", "Outputs.AppSg" ] }
+    },
+    "JenkinsIamRoleName": {
+      "Description": "Privilege-role assined to master node",
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-InstanceRoleName"}
+      },
+      "Value": { "Fn::GetAtt": [ "IamRes", "Outputs.InstanceRole" ] }
+    },
+    "JenkinsIamRoleProfile": {
+      "Description": "Privilege-role assined to master node",
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-InstanceRoleProfile"}
+      },
+      "Value": { "Fn::GetAtt": [ "IamRes", "Outputs.InstanceRoleProfile" ] }
+    },
+    "JenkinsS3Bucket": {
+      "Description": "Name of S3 bucket used for storing backup data.",
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-BackupBucket" }
+      },
+      "Value": { "Fn::GetAtt": [ "S3Res", "Outputs.JenkinsBucketName" ] }
+    },
+    "JenkinsVpcId": {
+      "Description": "VPC-ID that Jenkins stack is deployed into.",
+      "Export": {
+        "Name": { "Fn::Sub": "${AWS::StackName}-VpcId" }
+      },
+      "Value": { "Ref": "TargetVPC" }
+    }
+  },
+  "Parameters": {
+    "BucketTemplate": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL to the child-template for creating the Jenkins S3 backup-bucket.",
+      "Type": "String"
+    },
+    "IamRoleTemplate": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL to the child-template for creating the Jenkins IAM instance role.",
+      "Type": "String"
+    },
+    "JenkinsAgentPort": {
+      "Description": "TCP Port number that the Jenkins agent-hosts connect through.",
+      "MaxValue": "65535",
+      "MinValue": "1025",
+      "Type": "Number"
+    },
+    "JenkinsBackupBucket": {
+      "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
+      "Description": "S3 Bucket to host backup files (if left blank, a value will be computed).",
+      "Type": "String"
+    },
+    "ProtectedSubnets": {
+      "Description": "Select three subnets - each from different Availability Zones.",
+      "Type": "List<AWS::EC2::Subnet::Id>"
+    },
+    "RolePrefix": {
+      "Description": "Prefix to apply to IAM role to make things a bit prettier (optional).",
+      "Type": "String"
+    },
+    "SecurityGroupTemplate": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL to the child-template for creating the Jenkins network security-groups.",
+      "Type": "String"
+    },
+    "ServiceTld": {
+      "Default": "amazonaws.com",
+      "Description": "TLD of the IAMable service-name.",
+      "Type": "String"
+    },
+    "TargetVPC": {
+      "AllowedPattern": "^vpc-[0-9a-f]*$",
+      "Description": "ID of the VPC to deploy Jenkins components into.",
+      "Type": "AWS::EC2::VPC::Id"
+    }
+  },
+  "Resources": {
+    "IamRes": {
+      "Properties": {
+        "Parameters": {
+          "JenkinsBucketArn": {
+            "Fn::GetAtt": [ "S3Res", "Outputs.JenkinsBucketArn" ]
+          },
+          "RolePrefix": { "Ref": "RolePrefix" },
+          "ServiceTld": { "Ref": "ServiceTld" }
+        },
+        "TemplateURL": { "Ref": "IamRoleTemplate" },
+        "TimeoutInMinutes": "10"
+      },
+      "Type": "AWS::CloudFormation::Stack"
+    },
+    "S3Res": {
+      "Properties": {
+        "Parameters": {
+          "JenkinsBackupBucket": { "Ref": "JenkinsBackupBucket" }
+        },
+        "TemplateURL": { "Ref": "BucketTemplate" },
+        "TimeoutInMinutes": "10"
+      },
+      "Type": "AWS::CloudFormation::Stack"
+    },
+    "SgRes": {
+      "Properties": {
+        "Parameters": {
+          "JenkinsAgentPort": { "Ref": "JenkinsAgentPort" },
+          "TargetVPC": { "Ref": "TargetVPC" }
+        },
+        "TemplateURL": { "Ref": "SecurityGroupTemplate" },
+        "TimeoutInMinutes": "10"
+      },
+      "Type": "AWS::CloudFormation::Stack"
+    }
+  }
+}

--- a/Templates/make_jenkins_infra.tmplt.json
+++ b/Templates/make_jenkins_infra.tmplt.json
@@ -94,10 +94,6 @@
       "Description": "S3 Bucket to host backup files (if left blank, a value will be computed).",
       "Type": "String"
     },
-    "ProtectedSubnets": {
-      "Description": "Select three subnets - each from different Availability Zones.",
-      "Type": "List<AWS::EC2::Subnet::Id>"
-    },
     "RolePrefix": {
       "Description": "Prefix to apply to IAM role to make things a bit prettier (optional).",
       "Type": "String"


### PR DESCRIPTION
#### Description:

Makes usage of templates less monolithic to better support usage in  parallel deployment/upgrade scenario

#### Rationale:

Original service design was "upgrade in place". Primary consumer desires "parallel-build and migrate" upgrade process. 
 

#### Changes

1. Borrows previous, end-to-end "parent" CFn template (and associated Jenkins job) to create a reduced-scope, "infrastructure" template (and associated Jenkins job). New template/job deploys the VPC security-groups, S3 bucket and IAM roles.
1. Added Jenkins job to sync arbitrary source-bucket to arbitrary destination-bucket. It is expected that operator will use previous Jenkins master's S3 bucket as source and new Jenkins master's (newly-created, empty) bucket as destination. 
1. Upates EC2 CFn stacks' policy-timeouts to better account for the marked increase in recovery-set's size since original template-authoring

#### Remaining To-Dos

1. Write a Jenkins job to manage the ELB template deployment 
1. Write a Jenkins job to manage the EC2 template deployment &mdash; should include a registration-to-ELB `stage {}`

#### Migration Procedure Recommendation

1. Prior to upgrade window:
    1. Run the "infrastructure" pipeline in advance of planned migration window
    1. Run the "bucket-sync" pipeline in advance of planned migration window
1. During upgrade window:
    1. Stop old Jenkins master's Jenkins application
    1. Stop old Jenkins master's cron subsystem
    1. Do a final flush of `${JENKINS_HOME}` to S3
    1. Run the "bucket-sync" pipeline to do a delta-sync of old S3 bucket to new
    1. Deploy the EC2 and ELB templates