### PR TITLE
Add AutoScaling Template

### DIFF
--- a/Deployment/Jenkins/master/Master-Ec2-Autosacle.groovy
+++ b/Deployment/Jenkins/master/Master-Ec2-Autosacle.groovy
@@ -1,0 +1,335 @@
+pipeline {
+
+    agent any
+
+    options {
+        buildDiscarder(
+            logRotator(
+                numToKeepStr: '5',
+                daysToKeepStr: '30',
+                artifactDaysToKeepStr: '30',
+                artifactNumToKeepStr: '3'
+            )
+        )
+        disableConcurrentBuilds()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    environment {
+        AWS_DEFAULT_REGION = "${AwsRegion}"
+        AWS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+        REQUESTS_CA_BUNDLE = '/etc/pki/tls/certs/ca-bundle.crt'
+    }
+
+    parameters {
+        string(name: 'AwsRegion', defaultValue: 'us-east-1', description: 'Amazon region to deploy resources into')
+        string(name: 'AwsCred', description: 'Jenkins-stored AWS credential with which to execute cloud-layer commands')
+        string(name: 'GitCred', description: 'Jenkins-stored Git credential with which to execute git commands')
+        string(name: 'GitProjUrl', description: 'SSH URL from which to download the Jenkins git project')
+        string(name: 'GitProjBranch', description: 'Project-branch to use from the Jenkins git project')
+        string(name: 'CfnStackRoot', description: 'Unique token to prepend to all stack-element names')
+        string(name: 'TemplateUrl', description: 'S3-hosted URL for the EC2 template file')
+        string(name: 'AdminPubkeyURL', description: '(Optional) URL of file containing admin groups SSH public-keys')
+        string(name: 'AmiId', description: 'ID of the AMI to launch')
+        string(name: 'AppVolumeDevice', defaultValue: 'false', description: 'Decision whether to mount an extra EBS volume. Leave as default (\'false\') to launch without an extra application volume')
+        string(name: 'AppVolumeMountPath', defaultValue: '/var/lib/jenkins', description: 'Filesystem path to mount the extra app volume. Ignored if \'AppVolumeDevice\' is blank')
+        string(name: 'AppVolumeSize', defaultValue: '20', description: 'Size in GB of the EBS volume to create. Ignored if \'AppVolumeDevice\' is blank')
+        string(name: 'AppVolumeType', defaultValue: 'gp2', description: 'Type of EBS volume to create. Ignored if \'AppVolumeDevice\' is blank')
+        string(name: 'BackupBucket', description: 'S3 Bucket to host backups of Jenkins config-data')
+        string(name: 'BackupFolder', description: 'Folder in S3 Bucket to host backups of Jenkins config-data')
+        string(name: 'CfnBootstrapUtilsUrl', defaultValue: 'https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz', description: 'URL to aws-cfn-bootstrap-latest.tar.gz')
+        string(name: 'CfnEndpointUrl', defaultValue: 'https://cloudformation.us-east-1.amazonaws.com', description: '(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com')
+        string(name: 'CfnGetPipUrl', defaultValue: 'https://bootstrap.pypa.io/2.6/get-pip.py', description: 'URL to get-pip.py')
+        string(name: 'CloudWatchAgentUrl', defaultValue: '', description: '(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip')
+        string(name: 'DesiredCapacity', defaultValue: '1', description: 'Desired number of instances in the Autoscaling Group')
+        string(name: 'EpelRepo', defaultValue: 'epel', description: 'Name of available EPEL repo.')
+        string(name: 'InstanceRoleName', defaultValue: '', description: '(Optional) IAM instance role to apply to the instance')
+        string(name: 'InstanceRoleProfile', defaultValue: '', description: '(Optional) IAM instance-role profile to apply to the instance(s)')
+        string(name: 'InstanceType', defaultValue: 't2.xlarge', description: 'Amazon EC2 instance type')
+        string(name: 'JenkinsAppinstallScriptUrl', description: 'URL of Jenkins application-installer script (Must be anonymously fetchable or embed authenticated-fetch information).')
+        string(name: 'JenkinsOsPrepScriptUrl', description: 'URL of OS-preparation script (Must be anonymously fetchable or embed authenticated-fetch information).')
+        string(name: 'JenkinsRepoKeyURL', defaultValue: 'https://pkg.jenkins.io/redhat-stable/jenkins.io.key', description: 'URL to the Jenkins yum-repository GPG key')
+        string(name: 'JenkinsRepoURL', defaultValue: 'http://pkg.jenkins.io/redhat-stable', description: 'URL to the Jenkins yum-repository')
+        string(name: 'JenkinsRpmName', description: 'Name of Jenkins RPM to install. Include release version if "other-than-latest" is desired. Example values would be: jenkins, jenkins-2.*, jenkins-X.Y.Z, etc.')
+        string(name: 'KeyPairName', description: 'Public/private key pairs allow you to securely connect to your instance after it launches')
+        string(name: 'LoadBalancerNames', defaultValue: '', description: 'Comma-separated string of Classic ELB Names to associate with the Autoscaling Group; conflicts with TargetGroupArns')
+        string(name: 'MaxCapacity', defaultValue: '2', description: 'Maximum number of instances in the Autoscaling Group')
+        string(name: 'MinCapacity', defaultValue: '1', description: 'Minimum number of instances in the Autoscaling Group')
+        string(name: 'NoPublicIp', defaultValue: 'true', description: 'Controls whether to assign the instance a public IP. Recommended to leave at \'true\' _unless_ launching in a public subnet')
+        string(name: 'NoReboot', defaultValue: 'false', description: 'Controls whether to reboot the instance as the last step of cfn-init execution')
+        string(name: 'NoUpdates', defaultValue: 'false', description: 'Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)')
+        string(name: 'ProvisionUser', defaultValue: 'ec2-user', description: 'Name for remote-administration account')
+        string(name: 'PypiIndexUrl', defaultValue: 'https://pypi.org/simple', description: 'URL to the PyPi Index')
+        string(name: 'RootVolumeSize', defaultValue: '20', description: 'Size in GB of the EBS volume to create. If smaller than AMI defaul, create operation will fail; If larger, root device-volume partition size will be increased')
+        string(name: 'ScaleDownSchedule', defaultValue: '', description: '(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \'0 0 * * *\')')
+        string(name: 'ScaleUpSchedule', defaultValue: '', description: '(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \'0 10 * * Mon-Fri\')')
+        string(name: 'SecurityGroupIds', description: 'List of security groups to apply to the instance(s)')
+        string(name: 'SubnetIds', description: 'List of subnets to associate to the Autoscaling Group')
+        string(name: 'TargetGroupArns', defaultValue: '', description: 'Comma-separated string of Target Group ARNs to associate with the Autoscaling Group; conflicts with LoadBalancerNames')
+        string(name: 'ToggleCfnInitUpdate', defaultValue: 'A', description: 'A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence')
+        string(name: 'ToggleNewInstances', defaultValue: 'A', description: 'A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy')
+        string(name: 'WatchmakerAdminGroups', defaultValue: '', description: '(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance')
+        string(name: 'WatchmakerAdminUsers', defaultValue: '', description: '(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance')
+        string(name: 'WatchmakerComputerName', defaultValue: '', description: '(Optional) Sets the hostname/computername within the OS')
+        string(name: 'WatchmakerConfig', defaultValue: '', description: '(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)')
+        string(name: 'WatchmakerEnvironment', defaultValue: '', description: 'Environment in which the instance is being deployed')
+        string(name: 'WatchmakerOuPath', defaultValue: '', description: '(Optional) DN of the OU to place the instance when joining a domain. If blank and \'WatchmakerEnvironment\' enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \'WatchmakerEnvironment\' is \'false\'')
+    }
+
+    stages {
+        stage ('Prepare Instance Environment') {
+            steps {
+                deleteDir()
+                git branch: "${GitProjBranch}",
+                    credentialsId: "${GitCred}",
+                    url: "${GitProjUrl}"
+                writeFile file: 'Jenkins-Ec2-Master-ASG.parms.json',
+                    text: /
+                        [
+                            {
+                                "ParameterKey": "AdminPubkeyURL",
+                                "ParameterValue": "${env.AdminPubkeyURL}"
+                            },
+                            {
+                                "ParameterKey": "AmiId",
+                                "ParameterValue": "${env.AmiId}"
+                            },
+                            {
+                                "ParameterKey": "AppVolumeDevice",
+                                "ParameterValue": "${env.AppVolumeDevice}"
+                            },
+                            {
+                                "ParameterKey": "AppVolumeMountPath",
+                                "ParameterValue": "${env.AppVolumeMountPath}"
+                            },
+                            {
+                                "ParameterKey": "AppVolumeSize",
+                                "ParameterValue": "${env.AppVolumeSize}"
+                            },
+                            {
+                                "ParameterKey": "AppVolumeType",
+                                "ParameterValue": "${env.AppVolumeType}"
+                            },
+                            {
+                                "ParameterKey": "BackupBucket",
+                                "ParameterValue": "${env.BackupBucket}"
+                            },
+                            {
+                                "ParameterKey": "BackupFolder",
+                                "ParameterValue": "${env.BackupFolder}"
+                            },
+                            {
+                                "ParameterKey": "CfnBootstrapUtilsUrl",
+                                "ParameterValue": "${env.CfnBootstrapUtilsUrl}"
+                            },
+                            {
+                                "ParameterKey": "CfnEndpointUrl",
+                                "ParameterValue": "${env.CfnEndpointUrl}"
+                            },
+                            {
+                                "ParameterKey": "CfnGetPipUrl",
+                                "ParameterValue": "${env.CfnGetPipUrl}"
+                            },
+                            {
+                                "ParameterKey": "CloudWatchAgentUrl",
+                                "ParameterValue": "${env.CloudWatchAgentUrl}"
+                            },
+                            {
+                                "ParameterKey": "DesiredCapacity",
+                                "ParameterValue": "${env.DesiredCapacity}"
+                            },
+                            {
+                                "ParameterKey": "EpelRepo",
+                                "ParameterValue": "${env.EpelRepo}"
+                            },
+                            {
+                                "ParameterKey": "InstanceRoleName",
+                                "ParameterValue": "${env.InstanceRoleName}"
+                            },
+                            {
+                                "ParameterKey": "InstanceRoleProfile",
+                                "ParameterValue": "${env.InstanceRoleProfile}"
+                            },
+                            {
+                                "ParameterKey": "InstanceType",
+                                "ParameterValue": "${env.InstanceType}"
+                            },
+                            {
+                                "ParameterKey": "JenkinsAppinstallScriptUrl",
+                                "ParameterValue": "${env.JenkinsAppinstallScriptUrl}"
+                            },
+                            {
+                                "ParameterKey": "JenkinsOsPrepScriptUrl",
+                                "ParameterValue": "${env.JenkinsOsPrepScriptUrl}"
+                            },
+                            {
+                                "ParameterKey": "JenkinsRepoKeyURL",
+                                "ParameterValue": "${env.JenkinsRepoKeyURL}"
+                            },
+                            {
+                                "ParameterKey": "JenkinsRepoURL",
+                                "ParameterValue": "${env.JenkinsRepoURL}"
+                            },
+                            {
+                                "ParameterKey": "JenkinsRpmName",
+                                "ParameterValue": "${env.JenkinsRpmName}"
+                            },
+                            {
+                                "ParameterKey": "KeyPairName",
+                                "ParameterValue": "${env.KeyPairName}"
+                            },
+                            {
+                                "ParameterKey": "LoadBalancerNames",
+                                "ParameterValue": "${env.LoadBalancerNames}"
+                            },
+                            {
+                                "ParameterKey": "MaxCapacity",
+                                "ParameterValue": "${env.MaxCapacity}"
+                            },
+                            {
+                                "ParameterKey": "MinCapacity",
+                                "ParameterValue": "${env.MinCapacity}"
+                            },
+                            {
+                                "ParameterKey": "NoPublicIp",
+                                "ParameterValue": "${env.NoPublicIp}"
+                            },
+                            {
+                                "ParameterKey": "NoReboot",
+                                "ParameterValue": "${env.NoReboot}"
+                            },
+                            {
+                                "ParameterKey": "NoUpdates",
+                                "ParameterValue": "${env.NoUpdates}"
+                            },
+                            {
+                                "ParameterKey": "ProvisionUser",
+                                "ParameterValue": "${env.ProvisionUser}"
+                            },
+                            {
+                                "ParameterKey": "PypiIndexUrl",
+                                "ParameterValue": "${env.PypiIndexUrl}"
+                            },
+                            {
+                                "ParameterKey": "RootVolumeSize",
+                                "ParameterValue": "${env.RootVolumeSize}"
+                            },
+                            {
+                                "ParameterKey": "ScaleDownSchedule",
+                                "ParameterValue": "${env.ScaleDownSchedule}"
+                            },
+                            {
+                                "ParameterKey": "ScaleUpSchedule",
+                                "ParameterValue": "${env.ScaleUpSchedule}"
+                            },
+                            {
+                                "ParameterKey": "SecurityGroupIds",
+                                "ParameterValue": "${env.SecurityGroupIds}"
+                            },
+                            {
+                                "ParameterKey": "SubnetIds",
+                                "ParameterValue": "${env.SubnetIds}"
+                            },
+                            {
+                                "ParameterKey": "TargetGroupArns",
+                                "ParameterValue": "${env.TargetGroupArns}"
+                            },
+                            {
+                                "ParameterKey": "ToggleCfnInitUpdate",
+                                "ParameterValue": "${env.ToggleCfnInitUpdate}"
+                            },
+                            {
+                                "ParameterKey": "ToggleNewInstances",
+                                "ParameterValue": "${env.ToggleNewInstances}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerAdminGroups",
+                                "ParameterValue": "${env.WatchmakerAdminGroups}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerAdminUsers",
+                                "ParameterValue": "${env.WatchmakerAdminUsers}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerComputerName",
+                                "ParameterValue": "${env.WatchmakerComputerName}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerConfig",
+                                "ParameterValue": "${env.WatchmakerConfig}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerEnvironment",
+                                "ParameterValue": "${env.WatchmakerEnvironment}"
+                            },
+                            {
+                                "ParameterKey": "WatchmakerOuPath",
+                                "ParameterValue": "${env.WatchmakerOuPath}"
+                            }
+                        ]
+                    /
+                }
+            }
+        stage ('Prepare AWS Environment') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo "Attempting to delete any active ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} stacks..."
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}"
+
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} --region ${AwsRegion}
+                    '''
+                }
+            }
+        }
+        stage ('Launch Jenkins Master EC2 Instance Stack') {
+            steps {
+                withCredentials(
+                    [
+                        [$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: "${AwsCred}", secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']
+                    ]
+                ) {
+                    sh '''#!/bin/bash
+                        echo "Attempting to create stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER}..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}" \
+                          --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
+                          --template-url "${TemplateUrl}" \
+                          --parameters file://Jenkins-Ec2-Master-ASG.parms.json
+                        sleep 15
+
+                        # Pause if create is slow
+                        while [[ $(
+                                    aws cloudformation describe-stacks \
+                                      --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                      --query 'Stacks[].{Status:StackStatus}' \
+                                      --out text 2> /dev/null | \
+                                    grep -q CREATE_IN_PROGRESS
+                                   )$? -eq 0 ]]
+                        do
+                           echo "Waiting for stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} to finish create process..."
+                           sleep 30
+                        done
+
+                        if [[ $(
+                                aws cloudformation describe-stacks \
+                                  --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                  --query 'Stacks[].{Status:StackStatus}' \
+                                  --out text 2> /dev/null | \
+                                grep -q CREATE_COMPLETE
+                               )$? -eq 0 ]]
+                        then
+                           echo "Stack-creation successful"
+                        else
+                           echo "Stack-creation ended with non-successful state"
+                           exit 1
+                        fi
+                    '''
+                }
+            }
+        }
+    }
+}

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -3,7 +3,7 @@
   "Conditions": {
     "AssignInstanceRole": {
       "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] }
+        { "Fn::Equals": [ { "Ref": "InstanceRoleProfile" }, "" ] }
       ]
     },
     "AssignPublicIp": {
@@ -46,9 +46,19 @@
         { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] }
       ]
     },
+    "UseAdminPubkeyURL": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AdminPubkeyURL" }, "" ] }
+      ]
+    },
     "UseAdminUsers": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] }
+      ]
+    },
+    "UseCfnAppInstaller": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "JenkinsAppinstallScriptUrl" }, "" ] }
       ]
     },
     "UseCfnUrl": {
@@ -60,6 +70,11 @@
       "Fn::Or": [
         { "Condition": "UseLoadBalancerNames" },
         { "Condition": "UseTargetGroupArns" }
+      ]
+    },
+    "UseComputerName": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerComputerName" }, "" ] }
       ]
     },
     "UseEnvironment": {
@@ -85,6 +100,11 @@
             ""
           ]
         }
+      ]
+    },
+    "UseOsPrepScript": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "JenkinsOsPrepScriptUrl" }, "" ] }
       ]
     },
     "UseOuPath": {
@@ -286,6 +306,11 @@
     }
   },
   "Parameters": {
+    "AdminPubkeyURL": {
+      "AllowedPattern": "^http[s]?://.*|^$",
+      "Description": "(Optional) URL of file containing admin group's SSH public-keys",
+      "Type": "String"
+    },
     "AmiId": {
       "Description": "ID of the AMI to launch",
       "Type": "AWS::EC2::Image::Id"
@@ -301,13 +326,13 @@
     },
     "AppVolumeMountPath": {
       "AllowedPattern": "/.*",
-      "Default": "/opt/data",
+      "Default": "/var/lib/jenkins",
       "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
       "Type": "String"
     },
     "AppVolumeSize": {
       "ConstraintDescription": "Must be between 1GB and 16384GB.",
-      "Default": "1",
+      "Default": "20",
       "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
       "MaxValue": "16384",
       "MinValue": "1",
@@ -323,6 +348,16 @@
       ],
       "Default": "gp2",
       "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "BackupBucket": {
+      "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
+      "Description": "S3 Bucket to host backups of Jenkins config-data",
+      "Type": "String"
+    },
+    "BackupFolder": {
+      "AllowedPattern": "^[a-zA-Z]*[a-z0-9-]*[a-zA-Z]*$",
+      "Description": "Folder in S3 Bucket to host backups of Jenkins config-data",
       "Type": "String"
     },
     "CfnBootstrapUtilsUrl": {
@@ -354,30 +389,80 @@
       "Description": "Desired number of instances in the Autoscaling Group",
       "Type": "Number"
     },
-    "InstanceRole": {
+    "EpelRepo": {
+      "AllowedPattern": "^[a-z][a-z0-9-]*$",
+      "ConstraintDescription": "An alphanumeric string that represents the EPEL yum repo's label.",
+      "Default": "epel",
+      "Description": "Name of network's EPEL repo.",
+      "Type": "String"
+    },
+    "InstanceRoleName": {
       "Default": "",
-      "Description": "(Optional) IAM instance role to apply to the instance(s)",
+      "Description": "(Optional) IAM instance role to apply to the instance",
+      "Type": "String"
+    },
+    "InstanceRoleProfile": {
+      "Default": "",
+      "Description": "(Optional) IAM instance-role profile to apply to the instance(s)",
       "Type": "String"
     },
     "InstanceType": {
       "AllowedValues": [
-        "t2.micro",
-        "t2.small",
+        "t3.medium",
+        "t3.large",
+        "t3.xlarge",
+        "t3.2xlarge",
         "t2.medium",
         "t2.large",
         "t2.xlarge",
-        "c4.large",
-        "c4.xlarge",
+        "t2.2xlarge",
+        "m5.large",
+        "m5.xlarge",
+        "m5.2xlarge",
+        "m5.4xlarge",
         "m4.large",
         "m4.xlarge",
+        "m4.2xlarge",
+        "m4.4xlarge",
         "c5.large",
         "c5.xlarge",
-        "m5.large",
-        "m5.xlarge"
+        "c5.2xlarge",
+        "c5.4xlarge",
+        "c4.large",
+        "c4.xlarge",
+        "c4.4xlarge",
+        "c4.2xlarge"
       ],
-      "Default": "t2.micro",
+      "Default": "t2.xlarge",
       "Description": "Amazon EC2 instance type",
       "Type": "String"
+    },
+    "JenkinsAppinstallScriptUrl": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL of Jenkins application-installer script (Must be anonymously fetchable or embed authenticated-fetch information).",
+      "Type": "String"
+    },
+    "JenkinsOsPrepScriptUrl": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Description": "URL of OS-preparation script (Must be anonymously fetchable or embed authenticated-fetch information).",
+      "Type": "String"
+    },
+    "JenkinsRepoKeyURL": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Default": "https://pkg.jenkins.io/redhat-stable/jenkins.io.key",
+      "Description": "URL to the Jenkins yum-repository GPG key",
+      "Type": "String"
+    },
+    "JenkinsRepoURL": {
+      "AllowedPattern": "^$|^http://.*$|^https://.*$",
+      "Default": "http://pkg.jenkins.io/redhat-stable",
+      "Description": "URL to the Jenkins yum-repository",
+      "Type": "String"
+    },
+    "JenkinsRpmName": {
+      "Description": "Name of Jenkins RPM to install. Include release version if 'other-than-latest' is desired. Example values would be: jenkins, jenkins-2.*, jenkins-X.Y.Z, etc.",
+      "Type": "String",
+      "AllowedPattern": "^jenkins.*$"
     },
     "KeyPairName": {
       "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
@@ -423,6 +508,13 @@
       ],
       "Default": "false",
       "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+      "Type": "String"
+    },
+    "ProvisionUser": {
+      "AllowedPattern": "[a-z0-9-]{6,12}",
+      "ConstraintDescription": "Alphanumeric string between 6 and 12 characters.",
+      "Default": "ec2-user",
+      "Description": "Name for remote-administration account",
       "Type": "String"
     },
     "PypiIndexUrl": {
@@ -488,6 +580,11 @@
     "WatchmakerAdminUsers": {
       "Default": "",
       "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerComputerName": {
+      "Default": "",
+      "Description": "(Optional) Sets the hostname/computername within the OS",
       "Type": "String"
     },
     "WatchmakerConfig": {
@@ -599,6 +696,86 @@
     "WatchmakerLaunchConfig": {
       "Metadata": {
         "AWS::CloudFormation::Init": {
+          "admkey-install": {
+            "commands": {
+              "1-install-keyfile": {
+                "command": "bash -xe /etc/cfn/scripts/admkey.sh"
+              }
+            },
+            "files": {
+              "/etc/cfn/files/AdminKeys.pub": {
+                "source": { "Ref": "AdminPubkeyURL" },
+                "group": "root",
+                "mode": "000600",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/admkey.sh": {
+              "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "#!/bin/bash\n\n",
+                      "PROVHOME=$(getent passwd ",
+                      { "Ref": "ProvisionUser" },
+                      " | awk -F\":\" '{print $6}')\n",
+                      "\n",
+                      "install -b -m 000600 -o ",
+                      { "Ref": "ProvisionUser" },
+                      " -g ",
+                      { "Ref": "ProvisionUser" },
+                      " /etc/cfn/files/AdminKeys.pub ${PROVHOME}/.ssh/authorized_keys\n",
+                      "\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
+            }
+          },
+          "app-install": {
+            "files": {
+              "/etc/cfn/scripts/appinstall.sh": {
+                "source": { "Ref": "JenkinsAppinstallScriptUrl" },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/backups.cron": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "# Daily backup of JENKINS_HOME to S3\n",
+                      "0 23 * * * jenkins tar cf - ",
+                        { "Ref": "AppVolumeMountPath" },
+                        " | aws s3 cp - ",
+                        { "Ref": "BackupBucket" },
+                        "/Backups/daily/$(date '+\\%A').tar\n",
+                      "# Sync JENKINS_HOME to S3 for re-deployments\n",
+                      "*/20 * * * * jenkins tar cf - ",
+                        { "Ref": "AppVolumeMountPath" },
+                        " | aws s3 cp - s3://",
+                        { "Ref": "BackupBucket" },
+                        "/Backups/sync/JENKINS_HOME-$(date '+\\%M').tar\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
+            },
+            "commands": {
+              "1-appinstall-script": {
+                "command": "bash -xe /etc/cfn/scripts/appinstall.sh"
+              },
+              "2-install-backups_cron": {
+                "command": "install -b -m 000644 -o root -g root /etc/cfn/scripts/backups.cron /etc/cron.d/JenkinsMaster-backups"
+              }
+            }
+          },
           "configSets": {
             "launch": [
               "setup",
@@ -794,7 +971,7 @@
                               "",
                               [
                                 " --role ",
-                                { "Ref": "InstanceRole" }
+                                { "Ref": "InstanceRoleName" }
                               ]
                             ]
                           },
@@ -833,6 +1010,35 @@
               }
             }
           },
+          "osprep": {
+            "files": {
+              "/etc/cfn/scripts/osprep.sh": {
+                "source": { "Ref": "JenkinsOsPrepScriptUrl" },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
+            },
+            "commands": {
+              "1-osprep-script": {
+                "command": "bash -xe /etc/cfn/scripts/osprep.sh"
+              },
+              "2-packages-from-epel": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "yum --enablerepo=",
+                        { "Ref": "EpelRepo" },
+                        " install -y",
+                        " git",
+                        "\n"
+                    ]
+                  ]
+                }
+              }
+            }
+          },
           "reboot": {
             "commands": {
               "10-reboot": {
@@ -842,6 +1048,48 @@
           },
           "setup": {
             "files": {
+              "/etc/cfn/Jenkins.envs": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "JENKINS_APPINSTALL_SCRIPT=",
+                        { "Ref": "JenkinsAppinstallScriptUrl" },
+                        "\n",
+                      "JENKINS_BACKUP_BUCKET=",
+                        { "Ref": "BackupBucket" },
+                        "\n",
+                      "JENKINS_BACKUP_FOLDER=",
+                        { "Ref": "BackupFolder" },
+                        "\n",
+                      "JENKINS_CFN_ENDPOINT=",
+                        { "Ref": "CfnEndpointUrl" },
+                        "\n",
+                      "JENKINS_EPEL_REPO=",
+                        { "Ref": "EpelRepo" },
+                        "\n",
+                      "JENKINS_HOME_PATH=",
+                        { "Ref": "AppVolumeMountPath" },
+                        "\n",
+                      "JENKINS_OSPREP_SCRIPT=",
+                        { "Ref": "JenkinsOsPrepScriptUrl" },
+                        "\n",
+                      "JENKINS_RPM_NAME=",
+                        { "Ref": "JenkinsRpmName" },
+                        "\n",
+                      "JENKINS_YUM_URL=",
+                        { "Ref": "JenkinsRepoURL" },
+                        "\n",
+                      "JENKINS_YUMKEY_URL=",
+                        { "Ref": "JenkinsRepoKeyURL" },
+                        "\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
               "/etc/cfn/cfn-hup.conf": {
                 "content": {
                   "Fn::Join": [
@@ -862,7 +1110,7 @@
                               "",
                               [
                                 "role=",
-                                { "Ref": "InstanceRole" },
+                                { "Ref": "InstanceRoleName" },
                                 "\n"
                               ]
                             ]
@@ -917,7 +1165,7 @@
                               "",
                               [
                                 " --role ",
-                                { "Ref": "InstanceRole" }
+                                { "Ref": "InstanceRoleName" }
                               ]
                             ]
                           },
@@ -948,6 +1196,27 @@
                 },
                 "group": "root",
                 "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/yum.repos.d/jenkins.repo": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[jenkins]\n",
+                      "gpgkey = ",
+                      { "Ref": "JenkinsRepoKeyURL" },
+                      "\n",
+                      "enabled = 1\n",
+                      "baseurl = ",
+                      { "Ref": "JenkinsRepoURL" },
+                      "\n",
+                      "name = Jenkins CI service-repository\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000444",
                 "owner": "root"
               },
               "/etc/cfn/scripts/watchmaker-install.sh": {
@@ -1228,7 +1497,7 @@
         "IamInstanceProfile": {
           "Fn::If": [
             "AssignInstanceRole",
-            { "Ref": "InstanceRole" },
+            { "Ref": "InstanceRoleProfile" },
             { "Ref": "AWS::NoValue" }
           ]
         },
@@ -1257,6 +1526,16 @@
                 "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
                 "\n",
                 "#cloud-config\n",
+                "\n",
+                "system_info:\n",
+                "  default_user:\n",
+                "    name: ",
+                     { "Ref": "ProvisionUser" },
+                     "\n",
+                "\n",
+                "hostname: ",
+                { "Ref": "WatchmakerComputerName" },
+                "\n",
                 "\n",
                 "growpart:\n",
                 "  mode: auto\n",
@@ -1399,7 +1678,7 @@
                         "",
                         [
                           " --role ",
-                          { "Ref": "InstanceRole" }
+                          { "Ref": "InstanceRoleName" }
                         ]
                       ]
                     },
@@ -1437,7 +1716,7 @@
                         "",
                         [
                           " --role ",
-                          { "Ref": "InstanceRole" }
+                          { "Ref": "InstanceRoleName" }
                         ]
                       ]
                     },

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -1312,6 +1312,7 @@
                       "watchmaker --log-level debug",
                       " --log-dir /var/log/watchmaker",
                       " --no-reboot",
+                      " --exclude-states scap*scan",
                       {
                         "Fn::If": [
                           "UseWamConfig",

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -1,1869 +1,1567 @@
 {
-    "AWSTemplateFormatVersion": "2010-09-09",
-    "Conditions": {
-        "AssignInstanceRole": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "InstanceRole"
-                        },
-                        ""
-                    ]
-                }
-            ]
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "AssignInstanceRole": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] }
+      ]
+    },
+    "AssignPublicIp": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] }
+      ]
+    },
+    "CreateAppVolume": {
+      "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "true" ] },
+    "ExecuteAppScript": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] }
+      ]
+    },
+    "InstallCloudWatchAgent": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "CloudWatchAgentUrl" }, "" ] }
+      ]
+    },
+    "InstallUpdates": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
+      ]
+    },
+    "Reboot": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
+      ]
+    },
+    "SupportsNvme": {
+      "Fn::Equals": [
+        {
+          "Fn::FindInMap": [
+            "InstanceTypeMap",
+            { "Ref": "InstanceType" },
+            "SupportsNvme"
+          ]
         },
-        "AssignPublicIp": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NoPublicIp"
-                        },
-                        "true"
-                    ]
-                }
-            ]
-        },
-        "CreateAppVolume": {
-            "Fn::Equals": [
-                {
-                    "Ref": "AppVolumeDevice"
-                },
-                "true"
-            ]
-        },
-        "ExecuteAppScript": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "AppScriptUrl"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "InstallCloudWatchAgent": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "CloudWatchAgentUrl"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "InstallUpdates": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NoUpdates"
-                        },
-                        "true"
-                    ]
-                }
-            ]
-        },
-        "Reboot": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "NoReboot"
-                        },
-                        "true"
-                    ]
-                }
-            ]
-        },
-        "SupportsNvme": {
-            "Fn::Equals": [
-                {
-                    "Fn::FindInMap": [
-                        "InstanceTypeMap",
-                        {
-                            "Ref": "InstanceType"
-                        },
-                        "SupportsNvme"
-                    ]
-                },
-                "true"
-            ]
-        },
-        "UseAdminGroups": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "WatchmakerAdminGroups"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseAdminUsers": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "WatchmakerAdminUsers"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseCfnUrl": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "CfnEndpointUrl"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseElbHealthCheck": {
-            "Fn::Or": [
-                {
-                    "Condition": "UseLoadBalancerNames"
-                },
-                {
-                    "Condition": "UseTargetGroupArns"
-                }
-            ]
-        },
-        "UseEnvironment": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "WatchmakerEnvironment"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseLoadBalancerNames": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Fn::Join": [
-                                "",
-                                {
-                                    "Ref": "LoadBalancerNames"
-                                }
-                            ]
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseOuPath": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "WatchmakerOuPath"
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseScheduledAction": {
-            "Fn::And": [
-                {
-                    "Fn::Not": [
-                        {
-                            "Fn::Equals": [
-                                {
-                                    "Ref": "ScaleUpSchedule"
-                                },
-                                ""
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "Fn::Not": [
-                        {
-                            "Fn::Equals": [
-                                {
-                                    "Ref": "ScaleDownSchedule"
-                                },
-                                ""
-                            ]
-                        }
-                    ]
-                }
-            ]
-        },
-        "UseTargetGroupArns": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Fn::Join": [
-                                "",
-                                {
-                                    "Ref": "TargetGroupArns"
-                                }
-                            ]
-                        },
-                        ""
-                    ]
-                }
-            ]
-        },
-        "UseWamConfig": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "WatchmakerConfig"
-                        },
-                        ""
-                    ]
-                }
-            ]
+        "true"
+      ]
+    },
+    "UseAdminGroups": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] }
+      ]
+    },
+    "UseAdminUsers": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] }
+      ]
+    },
+    "UseCfnUrl": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "CfnEndpointUrl" }, "" ] }
+      ]
+    },
+    "UseElbHealthCheck": {
+      "Fn::Or": [
+        { "Condition": "UseLoadBalancerNames" },
+        { "Condition": "UseTargetGroupArns" }
+      ]
+    },
+    "UseEnvironment": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] }
+      ]
+    },
+    "UseLoadBalancerNames": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Join": [
+                "",
+                { "Ref": "LoadBalancerNames" }
+              ]
+            },
+            ""
+          ]
         }
+      ]
     },
-    "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
-    "Mappings": {
-        "Distro2RootDevice": {
-            "AmazonLinux": {
-                "DeviceName": "xvda"
-            },
-            "CentOS": {
-                "DeviceName": "sda1"
-            },
-            "RedHat": {
-                "DeviceName": "sda1"
-            }
+    "UseOuPath": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerOuPath" }, "" ] }
+      ]
+    },
+    "UseScheduledAction": {
+      "Fn::And": [
+        {
+          "Fn::Not": [
+            { "Fn::Equals": [ { "Ref": "ScaleUpSchedule" }, "" ] }
+          ]
         },
-        "InstanceTypeMap": {
-            "c4.large": {
-                "SupportsNvme": "false"
-            },
-            "c4.xlarge": {
-                "SupportsNvme": "false"
-            },
-            "c5.large": {
-                "SupportsNvme": "true"
-            },
-            "c5.xlarge": {
-                "SupportsNvme": "true"
-            },
-            "m4.large": {
-                "SupportsNvme": "false"
-            },
-            "m4.xlarge": {
-                "SupportsNvme": "false"
-            },
-            "m5.large": {
-                "SupportsNvme": "true"
-            },
-            "m5.xlarge": {
-                "SupportsNvme": "true"
-            },
-            "t2.large": {
-                "SupportsNvme": "false"
-            },
-            "t2.medium": {
-                "SupportsNvme": "false"
-            },
-            "t2.micro": {
-                "SupportsNvme": "false"
-            },
-            "t2.small": {
-                "SupportsNvme": "false"
-            },
-            "t2.xlarge": {
-                "SupportsNvme": "false"
-            }
+        {
+          "Fn::Not": [
+            { "Fn::Equals": [ { "Ref": "ScaleDownSchedule" }, "" ] }
+          ]
         }
+      ]
     },
-    "Metadata": {
-        "AWS::CloudFormation::Interface": {
-            "ParameterGroups": [
-                {
-                    "Label": {
-                        "default": "EC2 Instance Configuration"
-                    },
-                    "Parameters": [
-                        "AmiId",
-                        "AmiDistro",
-                        "InstanceType",
-                        "InstanceRole",
-                        "KeyPairName",
-                        "NoPublicIp",
-                        "NoReboot",
-                        "NoUpdates",
-                        "SecurityGroupIds"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "EC2 Watchmaker Configuration"
-                    },
-                    "Parameters": [
-                        "PypiIndexUrl",
-                        "WatchmakerConfig",
-                        "WatchmakerEnvironment",
-                        "WatchmakerOuPath",
-                        "WatchmakerAdminGroups",
-                        "WatchmakerAdminUsers"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "EC2 Application Configuration"
-                    },
-                    "Parameters": [
-                        "AppScriptUrl",
-                        "AppScriptParams",
-                        "AppScriptShell"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "EC2 Application EBS Volume"
-                    },
-                    "Parameters": [
-                        "AppVolumeDevice",
-                        "AppVolumeMountPath",
-                        "AppVolumeSize",
-                        "AppVolumeType"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "AutoScale Configuration"
-                    },
-                    "Parameters": [
-                        "DesiredCapacity",
-                        "MinCapacity",
-                        "MaxCapacity",
-                        "ScaleDownSchedule",
-                        "ScaleUpSchedule",
-                        "TargetGroupArns",
-                        "LoadBalancerNames"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Network Configuration"
-                    },
-                    "Parameters": [
-                        "SubnetIds"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "CloudFormation Configuration"
-                    },
-                    "Parameters": [
-                        "CfnEndpointUrl",
-                        "CfnGetPipUrl",
-                        "CfnBootstrapUtilsUrl",
-                        "CloudWatchAgentUrl",
-                        "ToggleCfnInitUpdate",
-                        "ToggleNewInstances"
-                    ]
-                }
-            ],
-            "ParameterLabels": {
-                "ToggleCfnInitUpdate": {
-                    "default": "Force Cfn Init Update"
-                },
-                "ToggleNewInstances": {
-                    "default": "Force New Instances"
-                }
-            }
-        },
-        "Version": "1.5.4"
-    },
-    "Outputs": {
-        "ScaleDownScheduledAction": {
-            "Condition": "UseScheduledAction",
-            "Description": "Scale Down Scheduled Action ID",
-            "Value": {
-                "Ref": "ScaleDownScheduledAction"
-            }
-        },
-        "ScaleUpScheduledAction": {
-            "Condition": "UseScheduledAction",
-            "Description": "Scale Up Scheduled Action ID",
-            "Value": {
-                "Ref": "ScaleUpScheduledAction"
-            }
-        },
-        "WatchmakerAutoScalingGroupId": {
-            "Description": "Autoscaling Group ID",
-            "Value": {
-                "Ref": "WatchmakerAutoScalingGroup"
-            }
-        },
-        "WatchmakerLaunchConfigId": {
-            "Description": "Launch Configuration ID",
-            "Value": {
-                "Ref": "WatchmakerLaunchConfig"
-            }
-        },
-        "WatchmakerLaunchConfigLogGroupName": {
-            "Condition": "InstallCloudWatchAgent",
-            "Description": "Log Group Name",
-            "Value": {
-                "Ref": "WatchmakerLaunchConfigLogGroup"
-            }
+    "UseTargetGroupArns": {
+      "Fn::Not": [
+        {
+          "Fn::Equals": [
+            {
+              "Fn::Join": [
+                "",
+                { "Ref": "TargetGroupArns" }
+              ]
+            },
+            ""
+          ]
         }
+      ]
     },
-    "Parameters": {
-        "AmiDistro": {
-            "AllowedValues": [
-                "AmazonLinux",
-                "CentOS",
-                "RedHat"
-            ],
-            "Description": "Linux distro of the AMI",
-            "Type": "String"
+    "UseWamConfig": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] }
+      ]
+    }
+  },
+  "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
+  "Mappings": {
+    "Distro2RootDevice": {
+      "AmazonLinux": {
+        "DeviceName": "xvda"
+      },
+      "CentOS": {
+        "DeviceName": "sda1"
+      },
+      "RedHat": {
+        "DeviceName": "sda1"
+      }
+    },
+    "InstanceTypeMap": {
+      "c4.large": {
+        "SupportsNvme": "false"
+      },
+      "c4.xlarge": {
+        "SupportsNvme": "false"
+      },
+      "c5.large": {
+        "SupportsNvme": "true"
+      },
+      "c5.xlarge": {
+        "SupportsNvme": "true"
+      },
+      "m4.large": {
+        "SupportsNvme": "false"
+      },
+      "m4.xlarge": {
+        "SupportsNvme": "false"
+      },
+      "m5.large": {
+        "SupportsNvme": "true"
+      },
+      "m5.xlarge": {
+        "SupportsNvme": "true"
+      },
+      "t2.large": {
+        "SupportsNvme": "false"
+      },
+      "t2.medium": {
+        "SupportsNvme": "false"
+      },
+      "t2.micro": {
+        "SupportsNvme": "false"
+      },
+      "t2.small": {
+        "SupportsNvme": "false"
+      },
+      "t2.xlarge": {
+        "SupportsNvme": "false"
+      }
+    }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "EC2 Instance Configuration"
+          },
+          "Parameters": [
+            "AmiId",
+            "AmiDistro",
+            "InstanceType",
+            "InstanceRole",
+            "KeyPairName",
+            "NoPublicIp",
+            "NoReboot",
+            "NoUpdates",
+            "SecurityGroupIds"
+          ]
         },
-        "AmiId": {
-            "Description": "ID of the AMI to launch",
-            "Type": "AWS::EC2::Image::Id"
+        {
+          "Label": {
+            "default": "EC2 Watchmaker Configuration"
+          },
+          "Parameters": [
+            "PypiIndexUrl",
+            "WatchmakerConfig",
+            "WatchmakerEnvironment",
+            "WatchmakerOuPath",
+            "WatchmakerAdminGroups",
+            "WatchmakerAdminUsers"
+          ]
         },
-        "AppScriptParams": {
-            "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type": "String"
+        {
+          "Label": {
+            "default": "EC2 Application Configuration"
+          },
+          "Parameters": [
+            "AppScriptUrl",
+            "AppScriptParams",
+            "AppScriptShell"
+          ]
         },
-        "AppScriptShell": {
-            "AllowedValues": [
-                "bash",
-                "python"
-            ],
-            "Default": "bash",
-            "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type": "String"
+        {
+          "Label": {
+            "default": "EC2 Application EBS Volume"
+          },
+          "Parameters": [
+            "AppVolumeDevice",
+            "AppVolumeMountPath",
+            "AppVolumeSize",
+            "AppVolumeType"
+          ]
         },
-        "AppScriptUrl": {
-            "AllowedPattern": "^$|^s3://(.*)$",
-            "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
-            "Default": "",
-            "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
-            "Type": "String"
+        {
+          "Label": {
+            "default": "AutoScale Configuration"
+          },
+          "Parameters": [
+            "DesiredCapacity",
+            "MinCapacity",
+            "MaxCapacity",
+            "ScaleDownSchedule",
+            "ScaleUpSchedule",
+            "TargetGroupArns",
+            "LoadBalancerNames"
+          ]
         },
-        "AppVolumeDevice": {
-            "AllowedValues": [
-                "true",
-                "false"
-            ],
-            "Default": "false",
-            "Description": "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
-            "Type": "String"
+        {
+          "Label": {
+            "default": "Network Configuration"
+          },
+          "Parameters": [
+            "SubnetIds"
+          ]
         },
-        "AppVolumeMountPath": {
-            "AllowedPattern": "/.*",
-            "Default": "/opt/data",
-            "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
-            "Type": "String"
-        },
-        "AppVolumeSize": {
-            "ConstraintDescription": "Must be between 1GB and 16384GB.",
-            "Default": "1",
-            "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "MaxValue": "16384",
-            "MinValue": "1",
-            "Type": "Number"
-        },
-        "AppVolumeType": {
-            "AllowedValues": [
-                "gp2",
-                "io1",
-                "sc1",
-                "st1",
-                "standard"
-            ],
-            "Default": "gp2",
-            "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "Type": "String"
-        },
-        "CfnBootstrapUtilsUrl": {
-            "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
-            "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-            "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
-            "Type": "String"
-        },
-        "CfnEndpointUrl": {
-            "AllowedPattern": "^$|^http[s]?://.*$",
-            "Default": "https://cloudformation.us-east-1.amazonaws.com",
-            "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-            "Type": "String"
-        },
-        "CfnGetPipUrl": {
-            "AllowedPattern": "^http[s]?://.*\\.py$",
-            "Default": "https://bootstrap.pypa.io/2.6/get-pip.py",
-            "Description": "URL to get-pip.py",
-            "Type": "String"
-        },
-        "CloudWatchAgentUrl": {
-            "AllowedPattern": "^$|^s3://.*$",
-            "Default": "",
-            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
-            "Type": "String"
-        },
-        "DesiredCapacity": {
-            "Default": "1",
-            "Description": "Desired number of instances in the Autoscaling Group",
-            "Type": "Number"
-        },
-        "InstanceRole": {
-            "Default": "",
-            "Description": "(Optional) IAM instance role to apply to the instance(s)",
-            "Type": "String"
-        },
-        "InstanceType": {
-            "AllowedValues": [
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "t2.xlarge",
-                "c4.large",
-                "c4.xlarge",
-                "m4.large",
-                "m4.xlarge",
-                "c5.large",
-                "c5.xlarge",
-                "m5.large",
-                "m5.xlarge"
-            ],
-            "Default": "t2.micro",
-            "Description": "Amazon EC2 instance type",
-            "Type": "String"
-        },
-        "KeyPairName": {
-            "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type": "AWS::EC2::KeyPair::KeyName"
-        },
-        "LoadBalancerNames": {
-            "Default": "",
-            "Description": "Comma-separated string of Classic ELB Names to associate with the Autoscaling Group; conflicts with TargetGroupArns",
-            "Type": "CommaDelimitedList"
-        },
-        "MaxCapacity": {
-            "Default": "2",
-            "Description": "Maximum number of instances in the Autoscaling Group",
-            "Type": "Number"
-        },
-        "MinCapacity": {
-            "Default": "1",
-            "Description": "Minimum number of instances in the Autoscaling Group",
-            "Type": "Number"
-        },
-        "NoPublicIp": {
-            "AllowedValues": [
-                "false",
-                "true"
-            ],
-            "Default": "true",
-            "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
-            "Type": "String"
-        },
-        "NoReboot": {
-            "AllowedValues": [
-                "false",
-                "true"
-            ],
-            "Default": "false",
-            "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
-            "Type": "String"
-        },
-        "NoUpdates": {
-            "AllowedValues": [
-                "false",
-                "true"
-            ],
-            "Default": "false",
-            "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
-            "Type": "String"
-        },
-        "PypiIndexUrl": {
-            "AllowedPattern": "^http[s]?://.*$",
-            "Default": "https://pypi.org/simple",
-            "Description": "URL to the PyPi Index",
-            "Type": "String"
-        },
-        "ScaleDownSchedule": {
-            "Default": "",
-            "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
-            "Type": "String"
-        },
-        "ScaleUpSchedule": {
-            "Default": "",
-            "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")",
-            "Type": "String"
-        },
-        "SecurityGroupIds": {
-            "Description": "List of security groups to apply to the instance(s)",
-            "Type": "List<AWS::EC2::SecurityGroup::Id>"
-        },
-        "SubnetIds": {
-            "Description": "List of subnets to associate to the Autoscaling Group",
-            "Type": "List<AWS::EC2::Subnet::Id>"
-        },
-        "TargetGroupArns": {
-            "Default": "",
-            "Description": "Comma-separated string of Target Group ARNs to associate with the Autoscaling Group; conflicts with LoadBalancerNames",
-            "Type": "CommaDelimitedList"
-        },
+        {
+          "Label": {
+            "default": "CloudFormation Configuration"
+          },
+          "Parameters": [
+            "CfnEndpointUrl",
+            "CfnGetPipUrl",
+            "CfnBootstrapUtilsUrl",
+            "CloudWatchAgentUrl",
+            "ToggleCfnInitUpdate",
+            "ToggleNewInstances"
+          ]
+        }
+      ],
+      "ParameterLabels": {
         "ToggleCfnInitUpdate": {
-            "AllowedValues": [
-                "A",
-                "B"
-            ],
-            "Default": "A",
-            "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
-            "Type": "String"
+          "default": "Force Cfn Init Update"
         },
         "ToggleNewInstances": {
-            "AllowedValues": [
-                "A",
-                "B"
-            ],
-            "Default": "A",
-            "Description": "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
-            "Type": "String"
-        },
-        "WatchmakerAdminGroups": {
-            "Default": "",
-            "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
-            "Type": "String"
-        },
-        "WatchmakerAdminUsers": {
-            "Default": "",
-            "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
-            "Type": "String"
-        },
-        "WatchmakerConfig": {
-            "AllowedPattern": "^$|^(http[s]?|s3|file)://.*$",
-            "Default": "",
-            "Description": "(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)",
-            "Type": "String"
-        },
-        "WatchmakerEnvironment": {
-            "AllowedValues": [
-                "",
-                "dev",
-                "test",
-                "prod"
-            ],
-            "Default": "",
-            "Description": "Environment in which the instance is being deployed",
-            "Type": "String"
-        },
-        "WatchmakerOuPath": {
-            "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$",
-            "Default": "",
-            "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
-            "Type": "String"
+          "default": "Force New Instances"
         }
+      }
     },
-    "Resources": {
-        "ScaleDownScheduledAction": {
-            "Condition": "UseScheduledAction",
-            "Properties": {
-                "AutoScalingGroupName": {
-                    "Ref": "WatchmakerAutoScalingGroup"
-                },
-                "DesiredCapacity": {
-                    "Ref": "MinCapacity"
-                },
-                "Recurrence": {
-                    "Ref": "ScaleDownSchedule"
-                }
-            },
-            "Type": "AWS::AutoScaling::ScheduledAction"
+    "Version": "1.5.4"
+  },
+  "Outputs": {
+    "ScaleDownScheduledAction": {
+      "Condition": "UseScheduledAction",
+      "Description": "Scale Down Scheduled Action ID",
+      "Value": { "Ref": "ScaleDownScheduledAction" }
+    },
+    "ScaleUpScheduledAction": {
+      "Condition": "UseScheduledAction",
+      "Description": "Scale Up Scheduled Action ID",
+      "Value": { "Ref": "ScaleUpScheduledAction" }
+    },
+    "WatchmakerAutoScalingGroupId": {
+      "Description": "Autoscaling Group ID",
+      "Value": { "Ref": "WatchmakerAutoScalingGroup" }
+    },
+    "WatchmakerLaunchConfigId": {
+      "Description": "Launch Configuration ID",
+      "Value": { "Ref": "WatchmakerLaunchConfig" }
+    },
+    "WatchmakerLaunchConfigLogGroupName": {
+      "Condition": "InstallCloudWatchAgent",
+      "Description": "Log Group Name",
+      "Value": { "Ref": "WatchmakerLaunchConfigLogGroup" }
+    }
+  },
+  "Parameters": {
+    "AmiDistro": {
+      "AllowedValues": [
+        "AmazonLinux",
+        "CentOS",
+        "RedHat"
+      ],
+      "Description": "Linux distro of the AMI",
+      "Type": "String"
+    },
+    "AmiId": {
+      "Description": "ID of the AMI to launch",
+      "Type": "AWS::EC2::Image::Id"
+    },
+    "AppScriptParams": {
+      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptShell": {
+      "AllowedValues": [
+        "bash",
+        "python"
+      ],
+      "Default": "bash",
+      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptUrl": {
+      "AllowedPattern": "^$|^s3://(.*)$",
+      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
+      "Default": "",
+      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
+      "Type": "String"
+    },
+    "AppVolumeDevice": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "false",
+      "Description": "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
+      "Type": "String"
+    },
+    "AppVolumeMountPath": {
+      "AllowedPattern": "/.*",
+      "Default": "/opt/data",
+      "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "AppVolumeSize": {
+      "ConstraintDescription": "Must be between 1GB and 16384GB.",
+      "Default": "1",
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "MaxValue": "16384",
+      "MinValue": "1",
+      "Type": "Number"
+    },
+    "AppVolumeType": {
+      "AllowedValues": [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ],
+      "Default": "gp2",
+      "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "CfnBootstrapUtilsUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
+      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
+      "Type": "String"
+    },
+    "CfnEndpointUrl": {
+      "AllowedPattern": "^$|^http[s]?://.*$",
+      "Default": "https://cloudformation.us-east-1.amazonaws.com",
+      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+      "Type": "String"
+    },
+    "CfnGetPipUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.py$",
+      "Default": "https://bootstrap.pypa.io/2.6/get-pip.py",
+      "Description": "URL to get-pip.py",
+      "Type": "String"
+    },
+    "CloudWatchAgentUrl": {
+      "AllowedPattern": "^$|^s3://.*$",
+      "Default": "",
+      "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
+      "Type": "String"
+    },
+    "DesiredCapacity": {
+      "Default": "1",
+      "Description": "Desired number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "InstanceRole": {
+      "Default": "",
+      "Description": "(Optional) IAM instance role to apply to the instance(s)",
+      "Type": "String"
+    },
+    "InstanceType": {
+      "AllowedValues": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "t2.xlarge",
+        "c4.large",
+        "c4.xlarge",
+        "m4.large",
+        "m4.xlarge",
+        "c5.large",
+        "c5.xlarge",
+        "m5.large",
+        "m5.xlarge"
+      ],
+      "Default": "t2.micro",
+      "Description": "Amazon EC2 instance type",
+      "Type": "String"
+    },
+    "KeyPairName": {
+      "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "LoadBalancerNames": {
+      "Default": "",
+      "Description": "Comma-separated string of Classic ELB Names to associate with the Autoscaling Group; conflicts with TargetGroupArns",
+      "Type": "CommaDelimitedList"
+    },
+    "MaxCapacity": {
+      "Default": "2",
+      "Description": "Maximum number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "MinCapacity": {
+      "Default": "1",
+      "Description": "Minimum number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "NoPublicIp": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "true",
+      "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+      "Type": "String"
+    },
+    "NoReboot": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
+      "Type": "String"
+    },
+    "NoUpdates": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+      "Type": "String"
+    },
+    "PypiIndexUrl": {
+      "AllowedPattern": "^http[s]?://.*$",
+      "Default": "https://pypi.org/simple",
+      "Description": "URL to the PyPi Index",
+      "Type": "String"
+    },
+    "ScaleDownSchedule": {
+      "Default": "",
+      "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
+      "Type": "String"
+    },
+    "ScaleUpSchedule": {
+      "Default": "",
+      "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")",
+      "Type": "String"
+    },
+    "SecurityGroupIds": {
+      "Description": "List of security groups to apply to the instance(s)",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
+    },
+    "SubnetIds": {
+      "Description": "List of subnets to associate to the Autoscaling Group",
+      "Type": "List<AWS::EC2::Subnet::Id>"
+    },
+    "TargetGroupArns": {
+      "Default": "",
+      "Description": "Comma-separated string of Target Group ARNs to associate with the Autoscaling Group; conflicts with LoadBalancerNames",
+      "Type": "CommaDelimitedList"
+    },
+    "ToggleCfnInitUpdate": {
+      "AllowedValues": [
+        "A",
+        "B"
+      ],
+      "Default": "A",
+      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+      "Type": "String"
+    },
+    "ToggleNewInstances": {
+      "AllowedValues": [
+        "A",
+        "B"
+      ],
+      "Default": "A",
+      "Description": "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
+      "Type": "String"
+    },
+    "WatchmakerAdminGroups": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerAdminUsers": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerConfig": {
+      "AllowedPattern": "^$|^(http[s]?|s3|file)://.*$",
+      "Default": "",
+      "Description": "(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)",
+      "Type": "String"
+    },
+    "WatchmakerEnvironment": {
+      "AllowedValues": [
+        "",
+        "dev",
+        "test",
+        "prod"
+      ],
+      "Default": "",
+      "Description": "Environment in which the instance is being deployed",
+      "Type": "String"
+    },
+    "WatchmakerOuPath": {
+      "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$",
+      "Default": "",
+      "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ScaleDownScheduledAction": {
+      "Condition": "UseScheduledAction",
+      "Properties": {
+        "AutoScalingGroupName": { "Ref": "WatchmakerAutoScalingGroup" },
+        "DesiredCapacity": { "Ref": "MinCapacity" },
+        "Recurrence": { "Ref": "ScaleDownSchedule" }
+      },
+      "Type": "AWS::AutoScaling::ScheduledAction"
+    },
+    "ScaleUpScheduledAction": {
+      "Condition": "UseScheduledAction",
+      "Properties": {
+        "AutoScalingGroupName": { "Ref": "WatchmakerAutoScalingGroup" },
+        "DesiredCapacity": { "Ref": "MaxCapacity" },
+        "Recurrence": { "Ref": "ScaleUpSchedule" }
+      },
+      "Type": "AWS::AutoScaling::ScheduledAction"
+    },
+    "WatchmakerAutoScalingGroup": {
+      "CreationPolicy": {
+        "ResourceSignal": {
+          "Count": { "Ref": "DesiredCapacity" },
+          "Timeout": "PT30M"
+        }
+      },
+      "Properties": {
+        "DesiredCapacity": { "Ref": "DesiredCapacity" },
+        "HealthCheckGracePeriod": {
+          "Fn::If": [
+            "UseElbHealthCheck",
+            3600,
+            { "Ref": "AWS::NoValue" }
+          ]
         },
-        "ScaleUpScheduledAction": {
-            "Condition": "UseScheduledAction",
-            "Properties": {
-                "AutoScalingGroupName": {
-                    "Ref": "WatchmakerAutoScalingGroup"
-                },
-                "DesiredCapacity": {
-                    "Ref": "MaxCapacity"
-                },
-                "Recurrence": {
-                    "Ref": "ScaleUpSchedule"
-                }
-            },
-            "Type": "AWS::AutoScaling::ScheduledAction"
+        "HealthCheckType": {
+          "Fn::If": [
+            "UseElbHealthCheck",
+            "ELB",
+            "EC2"
+          ]
         },
-        "WatchmakerAutoScalingGroup": {
-            "CreationPolicy": {
-                "ResourceSignal": {
-                    "Count": {
-                        "Ref": "DesiredCapacity"
-                    },
-                    "Timeout": "PT30M"
-                }
-            },
-            "Properties": {
-                "DesiredCapacity": {
-                    "Ref": "DesiredCapacity"
-                },
-                "HealthCheckGracePeriod": {
-                    "Fn::If": [
-                        "UseElbHealthCheck",
-                        3600,
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "HealthCheckType": {
-                    "Fn::If": [
-                        "UseElbHealthCheck",
-                        "ELB",
-                        "EC2"
-                    ]
-                },
-                "LaunchConfigurationName": {
-                    "Ref": "WatchmakerLaunchConfig"
-                },
-                "LoadBalancerNames": {
-                    "Fn::If": [
-                        "UseLoadBalancerNames",
-                        {
-                            "Ref": "LoadBalancerNames"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "MaxSize": {
-                    "Ref": "MaxCapacity"
-                },
-                "MinSize": {
-                    "Ref": "MinCapacity"
-                },
-                "Tags": [
-                    {
-                        "Key": "Name",
-                        "PropagateAtLaunch": true,
-                        "Value": {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    {
-                                        "Ref": "AWS::StackName"
-                                    }
-                                ]
-                            ]
-                        }
-                    }
-                ],
-                "TargetGroupARNs": {
-                    "Fn::If": [
-                        "UseTargetGroupArns",
-                        {
-                            "Ref": "TargetGroupArns"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
-                    ]
-                },
-                "VPCZoneIdentifier": {
-                    "Ref": "SubnetIds"
-                }
-            },
-            "Type": "AWS::AutoScaling::AutoScalingGroup",
-            "UpdatePolicy": {
-                "AutoScalingReplacingUpdate": {
-                    "WillReplace": "true"
-                }
+        "LaunchConfigurationName": { "Ref": "WatchmakerLaunchConfig" },
+        "LoadBalancerNames": {
+          "Fn::If": [
+            "UseLoadBalancerNames",
+            { "Ref": "LoadBalancerNames" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "MaxSize": { "Ref": "MaxCapacity" },
+        "MinSize": { "Ref": "MinCapacity" },
+        "Tags": [
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": true,
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  { "Ref": "AWS::StackName" }
+                ]
+              ]
             }
+          }
+        ],
+        "TargetGroupARNs": {
+          "Fn::If": [
+            "UseTargetGroupArns",
+            { "Ref": "TargetGroupArns" },
+            { "Ref": "AWS::NoValue" }
+          ]
         },
-        "WatchmakerLaunchConfig": {
-            "Metadata": {
-                "AWS::CloudFormation::Init": {
-                    "configSets": {
-                        "launch": [
-                            "setup",
-                            {
-                                "Fn::If": [
-                                    "InstallCloudWatchAgent",
-                                    "cw-agent-install",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            },
-                            "watchmaker-install",
-                            "watchmaker-launch",
-                            {
-                                "Fn::If": [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If": [
-                                    "Reboot",
-                                    "reboot",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            }
-                        ],
-                        "update": [
-                            "setup",
-                            {
-                                "Fn::If": [
-                                    "InstallUpdates",
-                                    "install-updates",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            },
-                            "watchmaker-install",
-                            "watchmaker-update",
-                            {
-                                "Fn::If": [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If": [
-                                    "Reboot",
-                                    "reboot",
-                                    {
-                                        "Ref": "AWS::NoValue"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "cw-agent-install": {
-                        "commands": {
-                            "01-get-cloudwatch-agent": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
-                                            " aws s3 cp ",
-                                            {
-                                                "Ref": "CloudWatchAgentUrl"
-                                            },
-                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "02-extract-cloudwatch-agent": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "yum -y install unzip &&",
-                                            "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "10-install-cloudwatch-agent": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            " bash -xe install.sh &&",
-                                            " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
-                                            " -a fetch-config -m ec2 -c",
-                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
-                                        ]
-                                    ]
-                                },
-                                "cwd": "/etc/cfn/scripts/aws-cw-agent"
-                            }
-                        },
-                        "files": {
-                            "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "{",
-                                            "    \"logs\": {\n",
-                                            "        \"logs_collected\": {\n",
-                                            "            \"files\": {\n",
-                                            "                \"collect_list\": [\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"/var/log/cfn-init.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"cfn_init_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"/var/log/messages\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"messages_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"/var/log/watchmaker/watchmaker.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    },\n",
-                                            "                    {\n",
-                                            "                        \"file_path\": \"/var/log/watchmaker/salt_call.debug.log\",\n",
-                                            "                        \"log_group_name\": \"",
-                                            {
-                                                "Fn::If": [
-                                                    "InstallCloudWatchAgent",
-                                                    {
-                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
-                                                    },
-                                                    {
-                                                        "Ref": "AWS::NoValue"
-                                                    }
-                                                ]
-                                            },
-                                            "\",\n",
-                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
-                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
-                                            "                    }\n",
-                                            "                ]\n",
-                                            "            }\n",
-                                            "        },\n",
-                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
-                                            "    }\n",
-                                            "}\n"
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "finalize": {
-                        "commands": {
-                            "10-signal-success": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "cfn-signal -e 0",
-                                            " --stack ",
-                                            {
-                                                "Ref": "AWS::StackName"
-                                            },
-                                            " --resource WatchmakerAutoScalingGroup",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRole"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseCfnUrl",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --url ",
-                                                                {
-                                                                    "Ref": "CfnEndpointUrl"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            " --region ",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "\n"
-                                        ]
-                                    ]
-                                },
-                                "ignoreErrors": "true"
-                            }
-                        }
-                    },
-                    "install-updates": {
-                        "commands": {
-                            "10-install-updates": {
-                                "command": "yum -y update"
-                            }
-                        }
-                    },
-                    "make-app": {
-                        "commands": {
-                            "05-get-appscript": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "mkdir -p /etc/cfn/scripts &&",
-                                            " aws s3 cp ",
-                                            {
-                                                "Ref": "AppScriptUrl"
-                                            },
-                                            " /etc/cfn/scripts/make-app",
-                                            " &&",
-                                            " chown root:root /etc/cfn/scripts/make-app &&",
-                                            " chmod 700 /etc/cfn/scripts/make-app"
-                                        ]
-                                    ]
-                                }
-                            },
-                            "10-make-app": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            {
-                                                "Ref": "AppScriptShell"
-                                            },
-                                            " /etc/cfn/scripts/make-app ",
-                                            {
-                                                "Ref": "AppScriptParams"
-                                            }
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "reboot": {
-                        "commands": {
-                            "10-reboot": {
-                                "command": "shutdown -r +1 &"
-                            }
-                        }
-                    },
-                    "setup": {
-                        "files": {
-                            "/etc/cfn/cfn-hup.conf": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "[main]\n",
-                                            "stack=",
-                                            {
-                                                "Ref": "AWS::StackId"
-                                            },
-                                            "\n",
-                                            "region=",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "\n",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                "role=",
-                                                                {
-                                                                    "Ref": "InstanceRole"
-                                                                },
-                                                                "\n"
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseCfnUrl",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                "url=",
-                                                                {
-                                                                    "Ref": "CfnEndpointUrl"
-                                                                },
-                                                                "\n"
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            "interval=1",
-                                            "\n",
-                                            "verbose=true",
-                                            "\n"
-                                        ]
-                                    ]
-                                },
-                                "group": "root",
-                                "mode": "000400",
-                                "owner": "root"
-                            },
-                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "[cfn-auto-reloader-hook]\n",
-                                            "triggers=post.update\n",
-                                            "path=Resources.WatchmakerLaunchConfig.Metadata\n",
-                                            "action=cfn-init -v -c update",
-                                            " --stack ",
-                                            {
-                                                "Ref": "AWS::StackName"
-                                            },
-                                            " --resource WatchmakerLaunchConfig",
-                                            {
-                                                "Fn::If": [
-                                                    "AssignInstanceRole",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --role ",
-                                                                {
-                                                                    "Ref": "InstanceRole"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseCfnUrl",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --url ",
-                                                                {
-                                                                    "Ref": "CfnEndpointUrl"
-                                                                }
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            " --region ",
-                                            {
-                                                "Ref": "AWS::Region"
-                                            },
-                                            "\n",
-                                            "runas=root\n"
-                                        ]
-                                    ]
-                                },
-                                "group": "root",
-                                "mode": "000400",
-                                "owner": "root"
-                            },
-                            "/etc/cfn/scripts/watchmaker-install.sh": {
-                                "content": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "#!/bin/bash\n\n",
-                                            "PYPI_URL=",
-                                            {
-                                                "Ref": "PypiIndexUrl"
-                                            },
-                                            "\n",
-                                            "curl --silent --show-error --retry 5 -L ",
-                                            {
-                                                "Ref": "CfnGetPipUrl"
-                                            },
-                                            " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
-                                            "\n",
-                                            "pip install",
-                                            " --index-url=\"$PYPI_URL\"",
-                                            " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"' boto3\n",
-                                            "pip install",
-                                            " --index-url=\"$PYPI_URL\"",
-                                            " --upgrade watchmaker\n\n"
-                                        ]
-                                    ]
-                                },
-                                "group": "root",
-                                "mode": "000700",
-                                "owner": "root"
-                            }
-                        },
-                        "services": {
-                            "sysvinit": {
-                                "cfn-hup": {
-                                    "enabled": "true",
-                                    "ensureRunning": "true",
-                                    "files": [
-                                        "/etc/cfn/cfn-hup.conf",
-                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "watchmaker-install": {
-                        "commands": {
-                            "10-watchmaker-install": {
-                                "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh"
-                            }
-                        }
-                    },
-                    "watchmaker-launch": {
-                        "commands": {
-                            "10-watchmaker-launch": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "watchmaker --log-level debug",
-                                            " --log-dir /var/log/watchmaker",
-                                            " --no-reboot",
-                                            {
-                                                "Fn::If": [
-                                                    "UseWamConfig",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --config \"",
-                                                                {
-                                                                    "Ref": "WatchmakerConfig"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseEnvironment",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --env \"",
-                                                                {
-                                                                    "Ref": "WatchmakerEnvironment"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseOuPath",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --ou-path \"",
-                                                                {
-                                                                    "Ref": "WatchmakerOuPath"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseAdminGroups",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --admin-groups \"",
-                                                                {
-                                                                    "Ref": "WatchmakerAdminGroups"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseAdminUsers",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --admin-users \"",
-                                                                {
-                                                                    "Ref": "WatchmakerAdminUsers"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            }
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "watchmaker-update": {
-                        "commands": {
-                            "10-watchmaker-update": {
-                                "command": {
-                                    "Fn::Join": [
-                                        "",
-                                        [
-                                            "watchmaker --log-level debug",
-                                            " --log-dir /var/log/watchmaker",
-                                            " --salt-states None",
-                                            " --no-reboot",
-                                            {
-                                                "Fn::If": [
-                                                    "UseWamConfig",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --config \"",
-                                                                {
-                                                                    "Ref": "WatchmakerConfig"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseEnvironment",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --env \"",
-                                                                {
-                                                                    "Ref": "WatchmakerEnvironment"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseOuPath",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --ou-path \"",
-                                                                {
-                                                                    "Ref": "WatchmakerOuPath"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseAdminGroups",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --admin-groups \"",
-                                                                {
-                                                                    "Ref": "WatchmakerAdminGroups"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            },
-                                            {
-                                                "Fn::If": [
-                                                    "UseAdminUsers",
-                                                    {
-                                                        "Fn::Join": [
-                                                            "",
-                                                            [
-                                                                " --admin-users \"",
-                                                                {
-                                                                    "Ref": "WatchmakerAdminUsers"
-                                                                },
-                                                                "\""
-                                                            ]
-                                                        ]
-                                                    },
-                                                    ""
-                                                ]
-                                            }
-                                        ]
-                                    ]
-                                }
-                            }
-                        }
-                    }
-                },
-                "ToggleCfnInitUpdate": {
-                    "Ref": "ToggleCfnInitUpdate"
-                }
-            },
-            "Properties": {
-                "AssociatePublicIpAddress": {
-                    "Fn::If": [
-                        "AssignPublicIp",
-                        true,
-                        false
+        "VPCZoneIdentifier": { "Ref": "SubnetIds" }
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingReplacingUpdate": {
+          "WillReplace": "true"
+        }
+      }
+    },
+    "WatchmakerLaunchConfig": {
+      "Metadata": {
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "launch": [
+              "setup",
+              {
+                "Fn::If": [
+                  "InstallCloudWatchAgent",
+                  "cw-agent-install",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "watchmaker-install",
+              "watchmaker-launch",
+              {
+                "Fn::If": [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If": [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ],
+            "update": [
+              "setup",
+              {
+                "Fn::If": [
+                  "InstallUpdates",
+                  "install-updates",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "watchmaker-install",
+              "watchmaker-update",
+              {
+                "Fn::If": [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If": [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ]
+          },
+          "cw-agent-install": {
+            "commands": {
+              "01-get-cloudwatch-agent": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
+                      " aws s3 cp ",
+                      { "Ref": "CloudWatchAgentUrl" },
+                      " /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
                     ]
+                  ]
+                }
+              },
+              "02-extract-cloudwatch-agent": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "yum -y install unzip &&",
+                      "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
+                    ]
+                  ]
+                }
+              },
+              "10-install-cloudwatch-agent": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      " bash -xe install.sh &&",
+                      " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
+                      " -a fetch-config -m ec2 -c",
+                      " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+                    ]
+                  ]
                 },
-                "BlockDeviceMappings": [
-                    {
-                        "DeviceName": {
-                            "Fn::Join": [
-                                "",
-                                [
-                                    "/dev/",
-                                    {
-                                        "Fn::FindInMap": [
-                                            "Distro2RootDevice",
-                                            {
-                                                "Ref": "AmiDistro"
-                                            },
-                                            "DeviceName"
-                                        ]
-                                    }
-                                ]
-                            ]
-                        },
-                        "Ebs": {
-                            "DeleteOnTermination": true,
-                            "VolumeType": "gp2"
-                        }
-                    },
-                    {
+                "cwd": "/etc/cfn/scripts/aws-cw-agent"
+              }
+            },
+            "files": {
+              "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "{",
+                      "  \"logs\": {\n",
+                      "    \"logs_collected\": {\n",
+                      "      \"files\": {\n",
+                      "        \"collect_list\": [\n",
+                      "          {\n",
+                      "            \"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",\n",
+                      "            \"log_group_name\": \"",
+                      {
                         "Fn::If": [
-                            "CreateAppVolume",
-                            {
-                                "DeviceName": "/dev/xvdf",
-                                "Ebs": {
-                                    "DeleteOnTermination": true,
-                                    "VolumeSize": {
-                                        "Ref": "AppVolumeSize"
-                                    },
-                                    "VolumeType": {
-                                        "Ref": "AppVolumeType"
-                                    }
-                                }
-                            },
-                            {
-                                "Ref": "AWS::NoValue"
-                            }
+                          "InstallCloudWatchAgent",
+                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "AWS::NoValue" }
                         ]
-                    }
-                ],
-                "IamInstanceProfile": {
-                    "Fn::If": [
-                        "AssignInstanceRole",
-                        {
-                            "Ref": "InstanceRole"
-                        },
-                        {
-                            "Ref": "AWS::NoValue"
-                        }
+                      },
+                      "\",\n",
+                      "            \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                      "            \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                      " },\n",
+                      "          {\n",
+                      "            \"file_path\": \"/var/log/cfn-init.log\",\n",
+                      "            \"log_group_name\": \"",
+                      {
+                        "Fn::If": [
+                          "InstallCloudWatchAgent",
+                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "AWS::NoValue" }
+                        ]
+                      },
+                      "\",\n",
+                      "            \"log_stream_name\": \"cfn_init_logs_{instance_id}\",\n",
+                      "            \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                      " },\n",
+                      "          {\n",
+                      "            \"file_path\": \"/var/log/messages\",\n",
+                      "            \"log_group_name\": \"",
+                      {
+                        "Fn::If": [
+                          "InstallCloudWatchAgent",
+                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "AWS::NoValue" }
+                        ]
+                      },
+                      "\",\n",
+                      "            \"log_stream_name\": \"messages_logs_{instance_id}\",\n",
+                      "            \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                      " },\n",
+                      "          {\n",
+                      "            \"file_path\": \"/var/log/watchmaker/watchmaker.log\",\n",
+                      "            \"log_group_name\": \"",
+                      {
+                        "Fn::If": [
+                          "InstallCloudWatchAgent",
+                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "AWS::NoValue" }
+                        ]
+                      },
+                      "\",\n",
+                      "            \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                      "            \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                      " },\n",
+                      "          {\n",
+                      "            \"file_path\": \"/var/log/watchmaker/salt_call.debug.log\",\n",
+                      "            \"log_group_name\": \"",
+                      {
+                        "Fn::If": [
+                          "InstallCloudWatchAgent",
+                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "AWS::NoValue" }
+                        ]
+                      },
+                      "\",\n",
+                      "            \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                      "            \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                      " }\n",
+                      "        ]\n",
+                      " }\n",
+                      " },\n",
+                      "    \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                      " }\n",
+                      "}\n"
                     ]
-                },
-                "ImageId": {
-                    "Ref": "AmiId"
-                },
-                "InstanceType": {
-                    "Ref": "InstanceType"
-                },
-                "KeyName": {
-                    "Ref": "KeyPairName"
-                },
-                "SecurityGroups": {
-                    "Ref": "SecurityGroupIds"
-                },
-                "UserData": {
-                    "Fn::Base64": {
-                        "Fn::Join": [
-                            "",
-                            [
-                                "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
-                                "MIME-Version: 1.0\n",
-                                "\n",
-                                "--===============3585321300151562773==\n",
-                                "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
-                                "MIME-Version: 1.0\n",
-                                "Content-Transfer-Encoding: 7bit\n",
-                                "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
-                                "\n",
-                                "#cloud-config\n",
-                                {
-                                    "Fn::If": [
-                                        "CreateAppVolume",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    "bootcmd:\n",
-                                                    "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                                                    {
-                                                        "Fn::If": [
-                                                            "SupportsNvme",
-                                                            "/dev/nvme1n1",
-                                                            "/dev/xvdf"
-                                                        ]
-                                                    },
-                                                    "\n",
-                                                    "mounts:\n",
-                                                    "- [ ",
-                                                    {
-                                                        "Fn::If": [
-                                                            "SupportsNvme",
-                                                            "/dev/nvme1n1",
-                                                            "/dev/xvdf"
-                                                        ]
-                                                    },
-                                                    ", ",
-                                                    {
-                                                        "Ref": "AppVolumeMountPath"
-                                                    },
-                                                    " ]\n"
-                                                ]
-                                            ]
-                                        },
-                                        {
-                                            "Ref": "AWS::NoValue"
-                                        }
-                                    ]
-                                },
-                                "\n",
-                                "--===============3585321300151562773==\n",
-                                "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
-                                "MIME-Version: 1.0\n",
-                                "Content-Transfer-Encoding: 7bit\n",
-                                "Content-Disposition: attachment; filename=\"script.sh\"\n",
-                                "\n",
-                                "#!/bin/bash -xe\n\n",
-                                "# CFN LaunchConfig Update Toggle: ",
-                                {
-                                    "Ref": "ToggleNewInstances"
-                                },
-                                "\n\n",
-                                "# Export AWS ENVs\n",
-                                "test -r /etc/aws/models/endpoints.json && export AWS_DATA_PATH=/etc/aws/models || true\n",
-                                "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
-                                "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
-                                "export AWS_DEFAULT_REGION=",
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                "\n\n",
-                                "# Get pip\n",
-                                "PYPI_URL=",
-                                {
-                                    "Ref": "PypiIndexUrl"
-                                },
-                                "\n",
-                                "curl --silent --show-error --retry 5 -L ",
-                                {
-                                    "Ref": "CfnGetPipUrl"
-                                },
-                                " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
-                                "\n\n",
-                                "# Add pip to path\n",
-                                "hash pip 2> /dev/null || ",
-                                "PATH=\"${PATH}:/usr/local/bin\"",
-                                "\n\n",
-                                "# Upgrade pip and setuptools\n",
-                                "pip install",
-                                " --index-url=\"$PYPI_URL\"",
-                                " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"'",
-                                "\n\n",
-                                "# Fix python urllib3 warnings\n",
-                                "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                                "pip install",
-                                " --index-url=\"$PYPI_URL\"",
-                                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' cffi\n",
-                                "pip install",
-                                " --index-url=\"$PYPI_URL\"",
-                                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' 'cryptography<2.2;python_version<\"2.7\"' 'cryptography;python_version>=\"2.7\"'",
-                                "\n\n",
-                                "if [[ $(rpm --quiet -q aws-cfn-bootstrap || pip show --quiet aws-cfn-bootstrap)$? -ne 0 ]]\n",
-                                "then\n",
-                                "  # Get cfn utils\n",
-                                "  pip install",
-                                " --index-url=\"$PYPI_URL\"",
-                                " --upgrade --upgrade-strategy only-if-needed ",
-                                {
-                                    "Ref": "CfnBootstrapUtilsUrl"
-                                },
-                                "\n\n",
-                                "  # Fixup cfn utils\n",
-                                "  INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat",
-                                " 2> /dev/null || echo /usr/init/redhat)\n",
-                                "  chmod 775 ${INITDIR}/cfn-hup\n",
-                                "  ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-                                "  chkconfig --add cfn-hup\n",
-                                "  chkconfig cfn-hup on\n",
-                                "  mkdir -p /opt/aws/bin\n",
-                                "  BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin",
-                                " 2> /dev/null || echo /usr/bin)\n",
-                                "  for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup",
-                                " cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-                                "  do\n",
-                                "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
-                                "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                                "  done\n\n",
-                                "fi\n\n",
-                                "# Remove gcc now that it is no longer needed\n",
-                                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
-                                "# Add cfn utils to path\n",
-                                "hash cfn-signal 2> /dev/null || ",
-                                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-                                "\n\n",
-                                "# Execute cfn-init\n",
-                                "cfn-init -v -c launch",
-                                " --stack ",
-                                {
-                                    "Ref": "AWS::StackName"
-                                },
-                                " --resource WatchmakerLaunchConfig",
-                                {
-                                    "Fn::If": [
-                                        "AssignInstanceRole",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --role ",
-                                                    {
-                                                        "Ref": "InstanceRole"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                {
-                                    "Fn::If": [
-                                        "UseCfnUrl",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --url ",
-                                                    {
-                                                        "Ref": "CfnEndpointUrl"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                " --region ",
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                " ||",
-                                " ( echo 'ERROR: cfn-init failed! Aborting!';",
-                                " cfn-signal -e 1",
-                                "  --stack ",
-                                {
-                                    "Ref": "AWS::StackName"
-                                },
-                                "  --resource WatchmakerAutoScalingGroup",
-                                {
-                                    "Fn::If": [
-                                        "AssignInstanceRole",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --role ",
-                                                    {
-                                                        "Ref": "InstanceRole"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                {
-                                    "Fn::If": [
-                                        "UseCfnUrl",
-                                        {
-                                            "Fn::Join": [
-                                                "",
-                                                [
-                                                    " --url ",
-                                                    {
-                                                        "Ref": "CfnEndpointUrl"
-                                                    }
-                                                ]
-                                            ]
-                                        },
-                                        ""
-                                    ]
-                                },
-                                "  --region ",
-                                {
-                                    "Ref": "AWS::Region"
-                                },
-                                ";",
-                                " exit 1",
-                                " )\n\n",
-                                "--===============3585321300151562773==--"
-                            ]
-                        ]
-                    }
+                  ]
                 }
+              }
+            }
+          },
+          "finalize": {
+            "commands": {
+              "10-signal-success": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "cfn-signal -e 0",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerAutoScalingGroup",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n"
+                    ]
+                  ]
+                },
+                "ignoreErrors": "true"
+              }
+            }
+          },
+          "install-updates": {
+            "commands": {
+              "10-install-updates": {
+                "command": "yum -y update"
+              }
+            }
+          },
+          "make-app": {
+            "commands": {
+              "05-get-appscript": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "mkdir -p /etc/cfn/scripts &&",
+                      " aws s3 cp ",
+                      { "Ref": "AppScriptUrl" },
+                      " /etc/cfn/scripts/make-app",
+                      " &&",
+                      " chown root:root /etc/cfn/scripts/make-app &&",
+                      " chmod 700 /etc/cfn/scripts/make-app"
+                    ]
+                  ]
+                }
+              },
+              "10-make-app": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      { "Ref": "AppScriptShell" },
+                      " /etc/cfn/scripts/make-app ",
+                      { "Ref": "AppScriptParams" }
+                    ]
+                  ]
+                }
+              }
+            }
+          },
+          "reboot": {
+            "commands": {
+              "10-reboot": {
+                "command": "shutdown -r +1 &"
+              }
+            }
+          },
+          "setup": {
+            "files": {
+              "/etc/cfn/cfn-hup.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[main]\n",
+                      "stack=",
+                      { "Ref": "AWS::StackId" },
+                      "\n",
+                      "region=",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "role=",
+                                { "Ref": "InstanceRole" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "url=",
+                                { "Ref": "CfnEndpointUrl" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      "interval=1",
+                      "\n",
+                      "verbose=true",
+                      "\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[cfn-auto-reloader-hook]\n",
+                      "triggers=post.update\n",
+                      "path=Resources.WatchmakerLaunchConfig.Metadata\n",
+                      "action=cfn-init -v -c update",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerLaunchConfig",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      "runas=root\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/watchmaker-install.sh": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "#!/bin/bash\n\n",
+                      "PYPI_URL=",
+                      { "Ref": "PypiIndexUrl" },
+                      "\n",
+                      "curl --silent --show-error --retry 5 -L ",
+                      { "Ref": "CfnGetPipUrl" },
+                      " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
+                      "\n",
+                      "pip install",
+                      " --index-url=\"$PYPI_URL\"",
+                      " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"' boto3\n",
+                      "pip install",
+                      " --index-url=\"$PYPI_URL\"",
+                      " --upgrade watchmaker\n\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
             },
-            "Type": "AWS::AutoScaling::LaunchConfiguration"
+            "services": {
+              "sysvinit": {
+                "cfn-hup": {
+                  "enabled": "true",
+                  "ensureRunning": "true",
+                  "files": [
+                    "/etc/cfn/cfn-hup.conf",
+                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                  ]
+                }
+              }
+            }
+          },
+          "watchmaker-install": {
+            "commands": {
+              "10-watchmaker-install": {
+                "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh"
+              }
+            }
+          },
+          "watchmaker-launch": {
+            "commands": {
+              "10-watchmaker-launch": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --ou-path \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          },
+          "watchmaker-update": {
+            "commands": {
+              "10-watchmaker-update": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --salt-states None",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --ou-path \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          }
         },
-        "WatchmakerLaunchConfigLogGroup": {
-            "Condition": "InstallCloudWatchAgent",
-            "Properties": {
-                "LogGroupName": {
-                    "Fn::Join": [
+        "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" }
+      },
+      "Properties": {
+        "AssociatePublicIpAddress": {
+          "Fn::If": [
+            "AssignPublicIp",
+            true,
+            false
+          ]
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": {
+              "Fn::Join": [
+                "",
+                [
+                  "/dev/",
+                  {
+                    "Fn::FindInMap": [
+                      "Distro2RootDevice",
+                      { "Ref": "AmiDistro" },
+                      "DeviceName"
+                    ]
+                  }
+                ]
+              ]
+            },
+            "Ebs": {
+              "DeleteOnTermination": true,
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "Fn::If": [
+              "CreateAppVolume",
+              {
+                "DeviceName": "/dev/xvdf",
+                "Ebs": {
+                  "DeleteOnTermination": true,
+                  "VolumeSize": { "Ref": "AppVolumeSize" },
+                  "VolumeType": { "Ref": "AppVolumeType" }
+                }
+              },
+              { "Ref": "AWS::NoValue" }
+            ]
+          }
+        ],
+        "IamInstanceProfile": {
+          "Fn::If": [
+            "AssignInstanceRole",
+            { "Ref": "InstanceRole" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "ImageId": { "Ref": "AmiId" },
+        "InstanceType": { "Ref": "InstanceType" },
+        "KeyName": { "Ref": "KeyPairName" },
+        "SecurityGroups": { "Ref": "SecurityGroupIds" },
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
+                "MIME-Version: 1.0\n",
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
+                "\n",
+                "#cloud-config\n",
+                {
+                  "Fn::If": [
+                    "CreateAppVolume",
+                    {
+                      "Fn::Join": [
                         "",
                         [
-                            "/aws/ec2/lx/",
-                            {
-                                "Ref": "AWS::StackName"
-                            }
+                          "bootcmd:\n",
+                          "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
+                          {
+                            "Fn::If": [
+                              "SupportsNvme",
+                              "/dev/nvme1n1",
+                              "/dev/xvdf"
+                            ]
+                          },
+                          "\n",
+                          "mounts:\n",
+                          "- [ ",
+                          {
+                            "Fn::If": [
+                              "SupportsNvme",
+                              "/dev/nvme1n1",
+                              "/dev/xvdf"
+                            ]
+                          },
+                          ", ",
+                          { "Ref": "AppVolumeMountPath" },
+                          " ]\n"
                         ]
-                    ]
-                }
-            },
-            "Type": "AWS::Logs::LogGroup"
+                      ]
+                    },
+                    { "Ref": "AWS::NoValue" }
+                  ]
+                },
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"script.sh\"\n",
+                "\n",
+                "#!/bin/bash -xe\n\n",
+                "# CFN LaunchConfig Update Toggle: ",
+                { "Ref": "ToggleNewInstances" },
+                "\n\n",
+                "# Export AWS ENVs\n",
+                "test -r /etc/aws/models/endpoints.json && export AWS_DATA_PATH=/etc/aws/models || true\n",
+                "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                "export AWS_DEFAULT_REGION=",
+                { "Ref": "AWS::Region" },
+                "\n\n",
+                "# Get pip\n",
+                "PYPI_URL=",
+                { "Ref": "PypiIndexUrl" },
+                "\n",
+                "curl --silent --show-error --retry 5 -L ",
+                { "Ref": "CfnGetPipUrl" },
+                " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
+                "\n\n",
+                "# Add pip to path\n",
+                "hash pip 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin\"",
+                "\n\n",
+                "# Upgrade pip and setuptools\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"'",
+                "\n\n",
+                "# Fix python urllib3 warnings\n",
+                "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' cffi\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' 'cryptography<2.2;python_version<\"2.7\"' 'cryptography;python_version>=\"2.7\"'",
+                "\n\n",
+                "if [[ $(rpm --quiet -q aws-cfn-bootstrap || pip show --quiet aws-cfn-bootstrap)$? -ne 0 ]]\n",
+                "then\n",
+                "  # Get cfn utils\n",
+                "  pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade --upgrade-strategy only-if-needed ",
+                { "Ref": "CfnBootstrapUtilsUrl" },
+                "\n\n",
+                "  # Fixup cfn utils\n",
+                "  INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat",
+                " 2> /dev/null || echo /usr/init/redhat)\n",
+                "  chmod 775 ${INITDIR}/cfn-hup\n",
+                "  ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                "  chkconfig --add cfn-hup\n",
+                "  chkconfig cfn-hup on\n",
+                "  mkdir -p /opt/aws/bin\n",
+                "  BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin",
+                " 2> /dev/null || echo /usr/bin)\n",
+                "  for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup",
+                " cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                "  do\n",
+                "  ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                "  echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                "  done\n\n",
+                "fi\n\n",
+                "# Remove gcc now that it is no longer needed\n",
+                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+                "# Add cfn utils to path\n",
+                "hash cfn-signal 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+                "\n\n",
+                "# Execute cfn-init\n",
+                "cfn-init -v -c launch",
+                " --stack ",
+                { "Ref": "AWS::StackName" },
+                " --resource WatchmakerLaunchConfig",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                " --region ",
+                { "Ref": "AWS::Region" },
+                " ||",
+                " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                " cfn-signal -e 1",
+                "  --stack ",
+                { "Ref": "AWS::StackName" },
+                "  --resource WatchmakerAutoScalingGroup",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                "  --region ",
+                { "Ref": "AWS::Region" },
+                ";",
+                " exit 1",
+                " )\n\n",
+                "--===============3585321300151562773==--"
+              ]
+            ]
+          }
         }
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration"
+    },
+    "WatchmakerLaunchConfigLogGroup": {
+      "Condition": "InstallCloudWatchAgent",
+      "Properties": {
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/ec2/lx/",
+              { "Ref": "AWS::StackName" }
+            ]
+          ]
+        }
+      },
+      "Type": "AWS::Logs::LogGroup"
     }
+  }
 }

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -67,6 +67,11 @@
         { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] }
       ]
     },
+    "UseKeyPair": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "KeyPairName" }, "" ] }
+      ]
+    },
     "UseLoadBalancerNames": {
       "Fn::Not": [
         {
@@ -376,7 +381,7 @@
     },
     "KeyPairName": {
       "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
-      "Type": "AWS::EC2::KeyPair::KeyName"
+      "Type": "String"
     },
     "LoadBalancerNames": {
       "Default": "",
@@ -1229,7 +1234,13 @@
         },
         "ImageId": { "Ref": "AmiId" },
         "InstanceType": { "Ref": "InstanceType" },
-        "KeyName": { "Ref": "KeyPairName" },
+        "KeyName": {
+          "Fn::If": [
+            "UseKeyPair",
+            { "Ref": "KeyPairName" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
         "SecurityGroups": { "Ref": "SecurityGroupIds" },
         "UserData": {
           "Fn::Base64": {

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -1,0 +1,1869 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Conditions": {
+        "AssignInstanceRole": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "InstanceRole"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "AssignPublicIp": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "NoPublicIp"
+                        },
+                        "true"
+                    ]
+                }
+            ]
+        },
+        "CreateAppVolume": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AppVolumeDevice"
+                },
+                "true"
+            ]
+        },
+        "ExecuteAppScript": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "AppScriptUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "InstallCloudWatchAgent": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CloudWatchAgentUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "InstallUpdates": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "NoUpdates"
+                        },
+                        "true"
+                    ]
+                }
+            ]
+        },
+        "Reboot": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "NoReboot"
+                        },
+                        "true"
+                    ]
+                }
+            ]
+        },
+        "SupportsNvme": {
+            "Fn::Equals": [
+                {
+                    "Fn::FindInMap": [
+                        "InstanceTypeMap",
+                        {
+                            "Ref": "InstanceType"
+                        },
+                        "SupportsNvme"
+                    ]
+                },
+                "true"
+            ]
+        },
+        "UseAdminGroups": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "WatchmakerAdminGroups"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseAdminUsers": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "WatchmakerAdminUsers"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseCfnUrl": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "CfnEndpointUrl"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseElbHealthCheck": {
+            "Fn::Or": [
+                {
+                    "Condition": "UseLoadBalancerNames"
+                },
+                {
+                    "Condition": "UseTargetGroupArns"
+                }
+            ]
+        },
+        "UseEnvironment": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "WatchmakerEnvironment"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseLoadBalancerNames": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Join": [
+                                "",
+                                {
+                                    "Ref": "LoadBalancerNames"
+                                }
+                            ]
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseOuPath": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "WatchmakerOuPath"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseScheduledAction": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "ScaleUpSchedule"
+                                },
+                                ""
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "ScaleDownSchedule"
+                                },
+                                ""
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "UseTargetGroupArns": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Fn::Join": [
+                                "",
+                                {
+                                    "Ref": "TargetGroupArns"
+                                }
+                            ]
+                        },
+                        ""
+                    ]
+                }
+            ]
+        },
+        "UseWamConfig": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "WatchmakerConfig"
+                        },
+                        ""
+                    ]
+                }
+            ]
+        }
+    },
+    "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
+    "Mappings": {
+        "Distro2RootDevice": {
+            "AmazonLinux": {
+                "DeviceName": "xvda"
+            },
+            "CentOS": {
+                "DeviceName": "sda1"
+            },
+            "RedHat": {
+                "DeviceName": "sda1"
+            }
+        },
+        "InstanceTypeMap": {
+            "c4.large": {
+                "SupportsNvme": "false"
+            },
+            "c4.xlarge": {
+                "SupportsNvme": "false"
+            },
+            "c5.large": {
+                "SupportsNvme": "true"
+            },
+            "c5.xlarge": {
+                "SupportsNvme": "true"
+            },
+            "m4.large": {
+                "SupportsNvme": "false"
+            },
+            "m4.xlarge": {
+                "SupportsNvme": "false"
+            },
+            "m5.large": {
+                "SupportsNvme": "true"
+            },
+            "m5.xlarge": {
+                "SupportsNvme": "true"
+            },
+            "t2.large": {
+                "SupportsNvme": "false"
+            },
+            "t2.medium": {
+                "SupportsNvme": "false"
+            },
+            "t2.micro": {
+                "SupportsNvme": "false"
+            },
+            "t2.small": {
+                "SupportsNvme": "false"
+            },
+            "t2.xlarge": {
+                "SupportsNvme": "false"
+            }
+        }
+    },
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "EC2 Instance Configuration"
+                    },
+                    "Parameters": [
+                        "AmiId",
+                        "AmiDistro",
+                        "InstanceType",
+                        "InstanceRole",
+                        "KeyPairName",
+                        "NoPublicIp",
+                        "NoReboot",
+                        "NoUpdates",
+                        "SecurityGroupIds"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "EC2 Watchmaker Configuration"
+                    },
+                    "Parameters": [
+                        "PypiIndexUrl",
+                        "WatchmakerConfig",
+                        "WatchmakerEnvironment",
+                        "WatchmakerOuPath",
+                        "WatchmakerAdminGroups",
+                        "WatchmakerAdminUsers"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "EC2 Application Configuration"
+                    },
+                    "Parameters": [
+                        "AppScriptUrl",
+                        "AppScriptParams",
+                        "AppScriptShell"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "EC2 Application EBS Volume"
+                    },
+                    "Parameters": [
+                        "AppVolumeDevice",
+                        "AppVolumeMountPath",
+                        "AppVolumeSize",
+                        "AppVolumeType"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "AutoScale Configuration"
+                    },
+                    "Parameters": [
+                        "DesiredCapacity",
+                        "MinCapacity",
+                        "MaxCapacity",
+                        "ScaleDownSchedule",
+                        "ScaleUpSchedule",
+                        "TargetGroupArns",
+                        "LoadBalancerNames"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Network Configuration"
+                    },
+                    "Parameters": [
+                        "SubnetIds"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "CloudFormation Configuration"
+                    },
+                    "Parameters": [
+                        "CfnEndpointUrl",
+                        "CfnGetPipUrl",
+                        "CfnBootstrapUtilsUrl",
+                        "CloudWatchAgentUrl",
+                        "ToggleCfnInitUpdate",
+                        "ToggleNewInstances"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "ToggleCfnInitUpdate": {
+                    "default": "Force Cfn Init Update"
+                },
+                "ToggleNewInstances": {
+                    "default": "Force New Instances"
+                }
+            }
+        },
+        "Version": "1.5.4"
+    },
+    "Outputs": {
+        "ScaleDownScheduledAction": {
+            "Condition": "UseScheduledAction",
+            "Description": "Scale Down Scheduled Action ID",
+            "Value": {
+                "Ref": "ScaleDownScheduledAction"
+            }
+        },
+        "ScaleUpScheduledAction": {
+            "Condition": "UseScheduledAction",
+            "Description": "Scale Up Scheduled Action ID",
+            "Value": {
+                "Ref": "ScaleUpScheduledAction"
+            }
+        },
+        "WatchmakerAutoScalingGroupId": {
+            "Description": "Autoscaling Group ID",
+            "Value": {
+                "Ref": "WatchmakerAutoScalingGroup"
+            }
+        },
+        "WatchmakerLaunchConfigId": {
+            "Description": "Launch Configuration ID",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfig"
+            }
+        },
+        "WatchmakerLaunchConfigLogGroupName": {
+            "Condition": "InstallCloudWatchAgent",
+            "Description": "Log Group Name",
+            "Value": {
+                "Ref": "WatchmakerLaunchConfigLogGroup"
+            }
+        }
+    },
+    "Parameters": {
+        "AmiDistro": {
+            "AllowedValues": [
+                "AmazonLinux",
+                "CentOS",
+                "RedHat"
+            ],
+            "Description": "Linux distro of the AMI",
+            "Type": "String"
+        },
+        "AmiId": {
+            "Description": "ID of the AMI to launch",
+            "Type": "AWS::EC2::Image::Id"
+        },
+        "AppScriptParams": {
+            "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
+            "Type": "String"
+        },
+        "AppScriptShell": {
+            "AllowedValues": [
+                "bash",
+                "python"
+            ],
+            "Default": "bash",
+            "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
+            "Type": "String"
+        },
+        "AppScriptUrl": {
+            "AllowedPattern": "^$|^s3://(.*)$",
+            "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
+            "Default": "",
+            "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
+            "Type": "String"
+        },
+        "AppVolumeDevice": {
+            "AllowedValues": [
+                "true",
+                "false"
+            ],
+            "Default": "false",
+            "Description": "Decision whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
+            "Type": "String"
+        },
+        "AppVolumeMountPath": {
+            "AllowedPattern": "/.*",
+            "Default": "/opt/data",
+            "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+            "Type": "String"
+        },
+        "AppVolumeSize": {
+            "ConstraintDescription": "Must be between 1GB and 16384GB.",
+            "Default": "1",
+            "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+            "MaxValue": "16384",
+            "MinValue": "1",
+            "Type": "Number"
+        },
+        "AppVolumeType": {
+            "AllowedValues": [
+                "gp2",
+                "io1",
+                "sc1",
+                "st1",
+                "standard"
+            ],
+            "Default": "gp2",
+            "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+            "Type": "String"
+        },
+        "CfnBootstrapUtilsUrl": {
+            "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
+            "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+            "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
+            "Type": "String"
+        },
+        "CfnEndpointUrl": {
+            "AllowedPattern": "^$|^http[s]?://.*$",
+            "Default": "https://cloudformation.us-east-1.amazonaws.com",
+            "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+            "Type": "String"
+        },
+        "CfnGetPipUrl": {
+            "AllowedPattern": "^http[s]?://.*\\.py$",
+            "Default": "https://bootstrap.pypa.io/2.6/get-pip.py",
+            "Description": "URL to get-pip.py",
+            "Type": "String"
+        },
+        "CloudWatchAgentUrl": {
+            "AllowedPattern": "^$|^s3://.*$",
+            "Default": "",
+            "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
+            "Type": "String"
+        },
+        "DesiredCapacity": {
+            "Default": "1",
+            "Description": "Desired number of instances in the Autoscaling Group",
+            "Type": "Number"
+        },
+        "InstanceRole": {
+            "Default": "",
+            "Description": "(Optional) IAM instance role to apply to the instance(s)",
+            "Type": "String"
+        },
+        "InstanceType": {
+            "AllowedValues": [
+                "t2.micro",
+                "t2.small",
+                "t2.medium",
+                "t2.large",
+                "t2.xlarge",
+                "c4.large",
+                "c4.xlarge",
+                "m4.large",
+                "m4.xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "m5.large",
+                "m5.xlarge"
+            ],
+            "Default": "t2.micro",
+            "Description": "Amazon EC2 instance type",
+            "Type": "String"
+        },
+        "KeyPairName": {
+            "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
+            "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "LoadBalancerNames": {
+            "Default": "",
+            "Description": "Comma-separated string of Classic ELB Names to associate with the Autoscaling Group; conflicts with TargetGroupArns",
+            "Type": "CommaDelimitedList"
+        },
+        "MaxCapacity": {
+            "Default": "2",
+            "Description": "Maximum number of instances in the Autoscaling Group",
+            "Type": "Number"
+        },
+        "MinCapacity": {
+            "Default": "1",
+            "Description": "Minimum number of instances in the Autoscaling Group",
+            "Type": "Number"
+        },
+        "NoPublicIp": {
+            "AllowedValues": [
+                "false",
+                "true"
+            ],
+            "Default": "true",
+            "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+            "Type": "String"
+        },
+        "NoReboot": {
+            "AllowedValues": [
+                "false",
+                "true"
+            ],
+            "Default": "false",
+            "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
+            "Type": "String"
+        },
+        "NoUpdates": {
+            "AllowedValues": [
+                "false",
+                "true"
+            ],
+            "Default": "false",
+            "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+            "Type": "String"
+        },
+        "PypiIndexUrl": {
+            "AllowedPattern": "^http[s]?://.*$",
+            "Default": "https://pypi.org/simple",
+            "Description": "URL to the PyPi Index",
+            "Type": "String"
+        },
+        "ScaleDownSchedule": {
+            "Default": "",
+            "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
+            "Type": "String"
+        },
+        "ScaleUpSchedule": {
+            "Default": "",
+            "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale up to MaxCapacity; ignored if empty or ScaleDownSchedule is unset (E.g. \"0 10 * * Mon-Fri\")",
+            "Type": "String"
+        },
+        "SecurityGroupIds": {
+            "Description": "List of security groups to apply to the instance(s)",
+            "Type": "List<AWS::EC2::SecurityGroup::Id>"
+        },
+        "SubnetIds": {
+            "Description": "List of subnets to associate to the Autoscaling Group",
+            "Type": "List<AWS::EC2::Subnet::Id>"
+        },
+        "TargetGroupArns": {
+            "Default": "",
+            "Description": "Comma-separated string of Target Group ARNs to associate with the Autoscaling Group; conflicts with LoadBalancerNames",
+            "Type": "CommaDelimitedList"
+        },
+        "ToggleCfnInitUpdate": {
+            "AllowedValues": [
+                "A",
+                "B"
+            ],
+            "Default": "A",
+            "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+            "Type": "String"
+        },
+        "ToggleNewInstances": {
+            "AllowedValues": [
+                "A",
+                "B"
+            ],
+            "Default": "A",
+            "Description": "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
+            "Type": "String"
+        },
+        "WatchmakerAdminGroups": {
+            "Default": "",
+            "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
+            "Type": "String"
+        },
+        "WatchmakerAdminUsers": {
+            "Default": "",
+            "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+            "Type": "String"
+        },
+        "WatchmakerConfig": {
+            "AllowedPattern": "^$|^(http[s]?|s3|file)://.*$",
+            "Default": "",
+            "Description": "(Optional) Path to a Watchmaker config file.  The config file path can be a remote source (i.e. http[s]://, s3://) or local directory (i.e. file://)",
+            "Type": "String"
+        },
+        "WatchmakerEnvironment": {
+            "AllowedValues": [
+                "",
+                "dev",
+                "test",
+                "prod"
+            ],
+            "Default": "",
+            "Description": "Environment in which the instance is being deployed",
+            "Type": "String"
+        },
+        "WatchmakerOuPath": {
+            "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$",
+            "Default": "",
+            "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
+            "Type": "String"
+        }
+    },
+    "Resources": {
+        "ScaleDownScheduledAction": {
+            "Condition": "UseScheduledAction",
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "WatchmakerAutoScalingGroup"
+                },
+                "DesiredCapacity": {
+                    "Ref": "MinCapacity"
+                },
+                "Recurrence": {
+                    "Ref": "ScaleDownSchedule"
+                }
+            },
+            "Type": "AWS::AutoScaling::ScheduledAction"
+        },
+        "ScaleUpScheduledAction": {
+            "Condition": "UseScheduledAction",
+            "Properties": {
+                "AutoScalingGroupName": {
+                    "Ref": "WatchmakerAutoScalingGroup"
+                },
+                "DesiredCapacity": {
+                    "Ref": "MaxCapacity"
+                },
+                "Recurrence": {
+                    "Ref": "ScaleUpSchedule"
+                }
+            },
+            "Type": "AWS::AutoScaling::ScheduledAction"
+        },
+        "WatchmakerAutoScalingGroup": {
+            "CreationPolicy": {
+                "ResourceSignal": {
+                    "Count": {
+                        "Ref": "DesiredCapacity"
+                    },
+                    "Timeout": "PT30M"
+                }
+            },
+            "Properties": {
+                "DesiredCapacity": {
+                    "Ref": "DesiredCapacity"
+                },
+                "HealthCheckGracePeriod": {
+                    "Fn::If": [
+                        "UseElbHealthCheck",
+                        3600,
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "HealthCheckType": {
+                    "Fn::If": [
+                        "UseElbHealthCheck",
+                        "ELB",
+                        "EC2"
+                    ]
+                },
+                "LaunchConfigurationName": {
+                    "Ref": "WatchmakerLaunchConfig"
+                },
+                "LoadBalancerNames": {
+                    "Fn::If": [
+                        "UseLoadBalancerNames",
+                        {
+                            "Ref": "LoadBalancerNames"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "MaxSize": {
+                    "Ref": "MaxCapacity"
+                },
+                "MinSize": {
+                    "Ref": "MinCapacity"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "PropagateAtLaunch": true,
+                        "Value": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    {
+                                        "Ref": "AWS::StackName"
+                                    }
+                                ]
+                            ]
+                        }
+                    }
+                ],
+                "TargetGroupARNs": {
+                    "Fn::If": [
+                        "UseTargetGroupArns",
+                        {
+                            "Ref": "TargetGroupArns"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "VPCZoneIdentifier": {
+                    "Ref": "SubnetIds"
+                }
+            },
+            "Type": "AWS::AutoScaling::AutoScalingGroup",
+            "UpdatePolicy": {
+                "AutoScalingReplacingUpdate": {
+                    "WillReplace": "true"
+                }
+            }
+        },
+        "WatchmakerLaunchConfig": {
+            "Metadata": {
+                "AWS::CloudFormation::Init": {
+                    "configSets": {
+                        "launch": [
+                            "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallCloudWatchAgent",
+                                    "cw-agent-install",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
+                            "watchmaker-install",
+                            "watchmaker-launch",
+                            {
+                                "Fn::If": [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If": [
+                                    "Reboot",
+                                    "reboot",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            }
+                        ],
+                        "update": [
+                            "setup",
+                            {
+                                "Fn::If": [
+                                    "InstallUpdates",
+                                    "install-updates",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
+                            "watchmaker-install",
+                            "watchmaker-update",
+                            {
+                                "Fn::If": [
+                                    "ExecuteAppScript",
+                                    "make-app",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            },
+                            "finalize",
+                            {
+                                "Fn::If": [
+                                    "Reboot",
+                                    "reboot",
+                                    {
+                                        "Ref": "AWS::NoValue"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "cw-agent-install": {
+                        "commands": {
+                            "01-get-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "install -Dbm 700 -o root -g root /dev/null /etc/cfn/scripts/AmazonCloudWatchAgent.zip &&",
+                                            " aws s3 cp ",
+                                            {
+                                                "Ref": "CloudWatchAgentUrl"
+                                            },
+                                            " /etc/cfn/scripts/AmazonCloudWatchAgent.zip"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "02-extract-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "yum -y install unzip &&",
+                                            "unzip /etc/cfn/scripts/AmazonCloudWatchAgent.zip -d /etc/cfn/scripts/aws-cw-agent"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "10-install-cloudwatch-agent": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            " bash -xe install.sh &&",
+                                            " /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl",
+                                            " -a fetch-config -m ec2 -c",
+                                            " file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s"
+                                        ]
+                                    ]
+                                },
+                                "cwd": "/etc/cfn/scripts/aws-cw-agent"
+                            }
+                        },
+                        "files": {
+                            "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "{",
+                                            "    \"logs\": {\n",
+                                            "        \"logs_collected\": {\n",
+                                            "            \"files\": {\n",
+                                            "                \"collect_list\": [\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cloudwatch_agent_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/cfn-init.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"cfn_init_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/messages\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"messages_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/watchmaker.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"watchmaker_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    },\n",
+                                            "                    {\n",
+                                            "                        \"file_path\": \"/var/log/watchmaker/salt_call.debug.log\",\n",
+                                            "                        \"log_group_name\": \"",
+                                            {
+                                                "Fn::If": [
+                                                    "InstallCloudWatchAgent",
+                                                    {
+                                                        "Ref": "WatchmakerLaunchConfigLogGroup"
+                                                    },
+                                                    {
+                                                        "Ref": "AWS::NoValue"
+                                                    }
+                                                ]
+                                            },
+                                            "\",\n",
+                                            "                        \"log_stream_name\": \"salt_call_debug_logs_{instance_id}\",\n",
+                                            "                        \"timestamp_format\": \"%H:%M:%S %y %b %-d\"\n",
+                                            "                    }\n",
+                                            "                ]\n",
+                                            "            }\n",
+                                            "        },\n",
+                                            "        \"log_stream_name\": \"default_logs_{instance_id}\"\n",
+                                            "    }\n",
+                                            "}\n"
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "finalize": {
+                        "commands": {
+                            "10-signal-success": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "cfn-signal -e 0",
+                                            " --stack ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            " --resource WatchmakerAutoScalingGroup",
+                                            {
+                                                "Fn::If": [
+                                                    "AssignInstanceRole",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --role ",
+                                                                {
+                                                                    "Ref": "InstanceRole"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseCfnUrl",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --url ",
+                                                                {
+                                                                    "Ref": "CfnEndpointUrl"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "ignoreErrors": "true"
+                            }
+                        }
+                    },
+                    "install-updates": {
+                        "commands": {
+                            "10-install-updates": {
+                                "command": "yum -y update"
+                            }
+                        }
+                    },
+                    "make-app": {
+                        "commands": {
+                            "05-get-appscript": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "mkdir -p /etc/cfn/scripts &&",
+                                            " aws s3 cp ",
+                                            {
+                                                "Ref": "AppScriptUrl"
+                                            },
+                                            " /etc/cfn/scripts/make-app",
+                                            " &&",
+                                            " chown root:root /etc/cfn/scripts/make-app &&",
+                                            " chmod 700 /etc/cfn/scripts/make-app"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "10-make-app": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            {
+                                                "Ref": "AppScriptShell"
+                                            },
+                                            " /etc/cfn/scripts/make-app ",
+                                            {
+                                                "Ref": "AppScriptParams"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "reboot": {
+                        "commands": {
+                            "10-reboot": {
+                                "command": "shutdown -r +1 &"
+                            }
+                        }
+                    },
+                    "setup": {
+                        "files": {
+                            "/etc/cfn/cfn-hup.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[main]\n",
+                                            "stack=",
+                                            {
+                                                "Ref": "AWS::StackId"
+                                            },
+                                            "\n",
+                                            "region=",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n",
+                                            {
+                                                "Fn::If": [
+                                                    "AssignInstanceRole",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                "role=",
+                                                                {
+                                                                    "Ref": "InstanceRole"
+                                                                },
+                                                                "\n"
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseCfnUrl",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                "url=",
+                                                                {
+                                                                    "Ref": "CfnEndpointUrl"
+                                                                },
+                                                                "\n"
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            "interval=1",
+                                            "\n",
+                                            "verbose=true",
+                                            "\n"
+                                        ]
+                                    ]
+                                },
+                                "group": "root",
+                                "mode": "000400",
+                                "owner": "root"
+                            },
+                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "[cfn-auto-reloader-hook]\n",
+                                            "triggers=post.update\n",
+                                            "path=Resources.WatchmakerLaunchConfig.Metadata\n",
+                                            "action=cfn-init -v -c update",
+                                            " --stack ",
+                                            {
+                                                "Ref": "AWS::StackName"
+                                            },
+                                            " --resource WatchmakerLaunchConfig",
+                                            {
+                                                "Fn::If": [
+                                                    "AssignInstanceRole",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --role ",
+                                                                {
+                                                                    "Ref": "InstanceRole"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseCfnUrl",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --url ",
+                                                                {
+                                                                    "Ref": "CfnEndpointUrl"
+                                                                }
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            " --region ",
+                                            {
+                                                "Ref": "AWS::Region"
+                                            },
+                                            "\n",
+                                            "runas=root\n"
+                                        ]
+                                    ]
+                                },
+                                "group": "root",
+                                "mode": "000400",
+                                "owner": "root"
+                            },
+                            "/etc/cfn/scripts/watchmaker-install.sh": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "#!/bin/bash\n\n",
+                                            "PYPI_URL=",
+                                            {
+                                                "Ref": "PypiIndexUrl"
+                                            },
+                                            "\n",
+                                            "curl --silent --show-error --retry 5 -L ",
+                                            {
+                                                "Ref": "CfnGetPipUrl"
+                                            },
+                                            " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
+                                            "\n",
+                                            "pip install",
+                                            " --index-url=\"$PYPI_URL\"",
+                                            " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"' boto3\n",
+                                            "pip install",
+                                            " --index-url=\"$PYPI_URL\"",
+                                            " --upgrade watchmaker\n\n"
+                                        ]
+                                    ]
+                                },
+                                "group": "root",
+                                "mode": "000700",
+                                "owner": "root"
+                            }
+                        },
+                        "services": {
+                            "sysvinit": {
+                                "cfn-hup": {
+                                    "enabled": "true",
+                                    "ensureRunning": "true",
+                                    "files": [
+                                        "/etc/cfn/cfn-hup.conf",
+                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "watchmaker-install": {
+                        "commands": {
+                            "10-watchmaker-install": {
+                                "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh"
+                            }
+                        }
+                    },
+                    "watchmaker-launch": {
+                        "commands": {
+                            "10-watchmaker-launch": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "watchmaker --log-level debug",
+                                            " --log-dir /var/log/watchmaker",
+                                            " --no-reboot",
+                                            {
+                                                "Fn::If": [
+                                                    "UseWamConfig",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --config \"",
+                                                                {
+                                                                    "Ref": "WatchmakerConfig"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseEnvironment",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --env \"",
+                                                                {
+                                                                    "Ref": "WatchmakerEnvironment"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseOuPath",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --ou-path \"",
+                                                                {
+                                                                    "Ref": "WatchmakerOuPath"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseAdminGroups",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --admin-groups \"",
+                                                                {
+                                                                    "Ref": "WatchmakerAdminGroups"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseAdminUsers",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --admin-users \"",
+                                                                {
+                                                                    "Ref": "WatchmakerAdminUsers"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "watchmaker-update": {
+                        "commands": {
+                            "10-watchmaker-update": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "watchmaker --log-level debug",
+                                            " --log-dir /var/log/watchmaker",
+                                            " --salt-states None",
+                                            " --no-reboot",
+                                            {
+                                                "Fn::If": [
+                                                    "UseWamConfig",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --config \"",
+                                                                {
+                                                                    "Ref": "WatchmakerConfig"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseEnvironment",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --env \"",
+                                                                {
+                                                                    "Ref": "WatchmakerEnvironment"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseOuPath",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --ou-path \"",
+                                                                {
+                                                                    "Ref": "WatchmakerOuPath"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseAdminGroups",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --admin-groups \"",
+                                                                {
+                                                                    "Ref": "WatchmakerAdminGroups"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            },
+                                            {
+                                                "Fn::If": [
+                                                    "UseAdminUsers",
+                                                    {
+                                                        "Fn::Join": [
+                                                            "",
+                                                            [
+                                                                " --admin-users \"",
+                                                                {
+                                                                    "Ref": "WatchmakerAdminUsers"
+                                                                },
+                                                                "\""
+                                                            ]
+                                                        ]
+                                                    },
+                                                    ""
+                                                ]
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "ToggleCfnInitUpdate": {
+                    "Ref": "ToggleCfnInitUpdate"
+                }
+            },
+            "Properties": {
+                "AssociatePublicIpAddress": {
+                    "Fn::If": [
+                        "AssignPublicIp",
+                        true,
+                        false
+                    ]
+                },
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": {
+                            "Fn::Join": [
+                                "",
+                                [
+                                    "/dev/",
+                                    {
+                                        "Fn::FindInMap": [
+                                            "Distro2RootDevice",
+                                            {
+                                                "Ref": "AmiDistro"
+                                            },
+                                            "DeviceName"
+                                        ]
+                                    }
+                                ]
+                            ]
+                        },
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "VolumeType": "gp2"
+                        }
+                    },
+                    {
+                        "Fn::If": [
+                            "CreateAppVolume",
+                            {
+                                "DeviceName": "/dev/xvdf",
+                                "Ebs": {
+                                    "DeleteOnTermination": true,
+                                    "VolumeSize": {
+                                        "Ref": "AppVolumeSize"
+                                    },
+                                    "VolumeType": {
+                                        "Ref": "AppVolumeType"
+                                    }
+                                }
+                            },
+                            {
+                                "Ref": "AWS::NoValue"
+                            }
+                        ]
+                    }
+                ],
+                "IamInstanceProfile": {
+                    "Fn::If": [
+                        "AssignInstanceRole",
+                        {
+                            "Ref": "InstanceRole"
+                        },
+                        {
+                            "Ref": "AWS::NoValue"
+                        }
+                    ]
+                },
+                "ImageId": {
+                    "Ref": "AmiId"
+                },
+                "InstanceType": {
+                    "Ref": "InstanceType"
+                },
+                "KeyName": {
+                    "Ref": "KeyPairName"
+                },
+                "SecurityGroups": {
+                    "Ref": "SecurityGroupIds"
+                },
+                "UserData": {
+                    "Fn::Base64": {
+                        "Fn::Join": [
+                            "",
+                            [
+                                "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
+                                "MIME-Version: 1.0\n",
+                                "\n",
+                                "--===============3585321300151562773==\n",
+                                "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
+                                "MIME-Version: 1.0\n",
+                                "Content-Transfer-Encoding: 7bit\n",
+                                "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
+                                "\n",
+                                "#cloud-config\n",
+                                {
+                                    "Fn::If": [
+                                        "CreateAppVolume",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    "bootcmd:\n",
+                                                    "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
+                                                    {
+                                                        "Fn::If": [
+                                                            "SupportsNvme",
+                                                            "/dev/nvme1n1",
+                                                            "/dev/xvdf"
+                                                        ]
+                                                    },
+                                                    "\n",
+                                                    "mounts:\n",
+                                                    "- [ ",
+                                                    {
+                                                        "Fn::If": [
+                                                            "SupportsNvme",
+                                                            "/dev/nvme1n1",
+                                                            "/dev/xvdf"
+                                                        ]
+                                                    },
+                                                    ", ",
+                                                    {
+                                                        "Ref": "AppVolumeMountPath"
+                                                    },
+                                                    " ]\n"
+                                                ]
+                                            ]
+                                        },
+                                        {
+                                            "Ref": "AWS::NoValue"
+                                        }
+                                    ]
+                                },
+                                "\n",
+                                "--===============3585321300151562773==\n",
+                                "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                                "MIME-Version: 1.0\n",
+                                "Content-Transfer-Encoding: 7bit\n",
+                                "Content-Disposition: attachment; filename=\"script.sh\"\n",
+                                "\n",
+                                "#!/bin/bash -xe\n\n",
+                                "# CFN LaunchConfig Update Toggle: ",
+                                {
+                                    "Ref": "ToggleNewInstances"
+                                },
+                                "\n\n",
+                                "# Export AWS ENVs\n",
+                                "test -r /etc/aws/models/endpoints.json && export AWS_DATA_PATH=/etc/aws/models || true\n",
+                                "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                                "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                                "export AWS_DEFAULT_REGION=",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "\n\n",
+                                "# Get pip\n",
+                                "PYPI_URL=",
+                                {
+                                    "Ref": "PypiIndexUrl"
+                                },
+                                "\n",
+                                "curl --silent --show-error --retry 5 -L ",
+                                {
+                                    "Ref": "CfnGetPipUrl"
+                                },
+                                " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
+                                "\n\n",
+                                "# Add pip to path\n",
+                                "hash pip 2> /dev/null || ",
+                                "PATH=\"${PATH}:/usr/local/bin\"",
+                                "\n\n",
+                                "# Upgrade pip and setuptools\n",
+                                "pip install",
+                                " --index-url=\"$PYPI_URL\"",
+                                " --upgrade 'pip<10' 'setuptools<37;python_version<\"2.7\"' 'setuptools;python_version>=\"2.7\"'",
+                                "\n\n",
+                                "# Fix python urllib3 warnings\n",
+                                "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                                "pip install",
+                                " --index-url=\"$PYPI_URL\"",
+                                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' cffi\n",
+                                "pip install",
+                                " --index-url=\"$PYPI_URL\"",
+                                " --upgrade 'pycparser<2.19;python_version<\"2.7\"' 'cryptography<2.2;python_version<\"2.7\"' 'cryptography;python_version>=\"2.7\"'",
+                                "\n\n",
+                                "if [[ $(rpm --quiet -q aws-cfn-bootstrap || pip show --quiet aws-cfn-bootstrap)$? -ne 0 ]]\n",
+                                "then\n",
+                                "  # Get cfn utils\n",
+                                "  pip install",
+                                " --index-url=\"$PYPI_URL\"",
+                                " --upgrade --upgrade-strategy only-if-needed ",
+                                {
+                                    "Ref": "CfnBootstrapUtilsUrl"
+                                },
+                                "\n\n",
+                                "  # Fixup cfn utils\n",
+                                "  INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat",
+                                " 2> /dev/null || echo /usr/init/redhat)\n",
+                                "  chmod 775 ${INITDIR}/cfn-hup\n",
+                                "  ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                                "  chkconfig --add cfn-hup\n",
+                                "  chkconfig cfn-hup on\n",
+                                "  mkdir -p /opt/aws/bin\n",
+                                "  BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin",
+                                " 2> /dev/null || echo /usr/bin)\n",
+                                "  for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup",
+                                " cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                                "  do\n",
+                                "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                                "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                                "  done\n\n",
+                                "fi\n\n",
+                                "# Remove gcc now that it is no longer needed\n",
+                                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+                                "# Add cfn utils to path\n",
+                                "hash cfn-signal 2> /dev/null || ",
+                                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+                                "\n\n",
+                                "# Execute cfn-init\n",
+                                "cfn-init -v -c launch",
+                                " --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                " --resource WatchmakerLaunchConfig",
+                                {
+                                    "Fn::If": [
+                                        "AssignInstanceRole",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    " --role ",
+                                                    {
+                                                        "Ref": "InstanceRole"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "UseCfnUrl",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    " --url ",
+                                                    {
+                                                        "Ref": "CfnEndpointUrl"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                " --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                " ||",
+                                " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                                " cfn-signal -e 1",
+                                "  --stack ",
+                                {
+                                    "Ref": "AWS::StackName"
+                                },
+                                "  --resource WatchmakerAutoScalingGroup",
+                                {
+                                    "Fn::If": [
+                                        "AssignInstanceRole",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    " --role ",
+                                                    {
+                                                        "Ref": "InstanceRole"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                {
+                                    "Fn::If": [
+                                        "UseCfnUrl",
+                                        {
+                                            "Fn::Join": [
+                                                "",
+                                                [
+                                                    " --url ",
+                                                    {
+                                                        "Ref": "CfnEndpointUrl"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        ""
+                                    ]
+                                },
+                                "  --region ",
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                ";",
+                                " exit 1",
+                                " )\n\n",
+                                "--===============3585321300151562773==--"
+                            ]
+                        ]
+                    }
+                }
+            },
+            "Type": "AWS::AutoScaling::LaunchConfiguration"
+        },
+        "WatchmakerLaunchConfigLogGroup": {
+            "Condition": "InstallCloudWatchAgent",
+            "Properties": {
+                "LogGroupName": {
+                    "Fn::Join": [
+                        "",
+                        [
+                            "/aws/ec2/lx/",
+                            {
+                                "Ref": "AWS::StackName"
+                            }
+                        ]
+                    ]
+                }
+            },
+            "Type": "AWS::Logs::LogGroup"
+        }
+    }
+}

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -196,12 +196,43 @@
           "Parameters": [
             "AmiId",
             "InstanceType",
-            "InstanceRole",
+            "RootVolumeSize",
+            "ProvisionUser",
             "KeyPairName",
+            "AdminPubkeyURL",
+            "InstanceRoleName",
+            "InstanceRoleProfile",
+            "SubnetIds",
             "NoPublicIp",
             "NoReboot",
             "NoUpdates",
             "SecurityGroupIds"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Jenkins EBS Volume"
+          },
+          "Parameters": [
+            "AppVolumeDevice",
+            "AppVolumeMountPath",
+            "AppVolumeSize",
+            "AppVolumeType"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Jenkins Application Configuration"
+          },
+          "Parameters": [
+            "JenkinsOsPrepScriptUrl",
+            "JenkinsAppinstallScriptUrl",
+            "JenkinsRpmName",
+            "EpelRepo",
+            "JenkinsRepoURL",
+            "JenkinsRepoKeyURL",
+            "BackupBucket",
+            "BackupFolder"
           ]
         },
         {
@@ -212,20 +243,10 @@
             "PypiIndexUrl",
             "WatchmakerConfig",
             "WatchmakerEnvironment",
+            "WatchmakerComputerName",
             "WatchmakerOuPath",
             "WatchmakerAdminGroups",
             "WatchmakerAdminUsers"
-          ]
-        },
-        {
-          "Label": {
-            "default": "EC2 Application EBS Volume"
-          },
-          "Parameters": [
-            "AppVolumeDevice",
-            "AppVolumeMountPath",
-            "AppVolumeSize",
-            "AppVolumeType"
           ]
         },
         {
@@ -240,14 +261,6 @@
             "ScaleUpSchedule",
             "TargetGroupArns",
             "LoadBalancerNames"
-          ]
-        },
-        {
-          "Label": {
-            "default": "Network Configuration"
-          },
-          "Parameters": [
-            "SubnetIds"
           ]
         },
         {

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -460,6 +460,14 @@
       "Description": "URL to the PyPi Index",
       "Type": "String"
     },
+    "RootVolumeSize": {
+      "ConstraintDescription": "Must be between 20GB and 16384GB.",
+      "Default": "20",
+      "Description": "Size in GB of the EBS volume to create. If smaller than AMI defaul, create operation will fail; If larger, root device-volume's partition size will be increased",
+      "MaxValue": "16384",
+      "MinValue": "20",
+      "Type": "Number"
+    },
     "ScaleDownSchedule": {
       "Default": "",
       "Description": "(Optional) Scheduled Action in cron-format (UTC) to scale down to MinCapacity; ignored if empty or ScaleUpSchedule is unset (E.g. \"0 0 * * *\")",
@@ -1273,6 +1281,7 @@
             "DeviceName": "/dev/sda1",
             "Ebs": {
               "DeleteOnTermination": true,
+              "VolumeSize": { "Ref": "RootVolumeSize" },
               "VolumeType": "gp2"
             }
           },
@@ -1317,6 +1326,12 @@
                 "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
                 "\n",
                 "#cloud-config\n",
+                "\n",
+                "growpart:\n",
+                "  mode: auto\n",
+                "  devices: [ '/dev/xvda', '/dev/xvda2', '/dev/nvme0n1p2' ]\n",
+                "  ignore_growroot_disabled: false\n",
+                "\n",
                 {
                   "Fn::If": [
                     "CreateAppVolume",
@@ -1363,6 +1378,19 @@
                 "# CFN LaunchConfig Update Toggle: ",
                 { "Ref": "ToggleNewInstances" },
                 "\n\n",
+                "\n",
+                "# Extend any available LVM PVs\n",
+                "if [[ -x $( which pvs ) ]]\n",
+                "then\n",
+                "   LVMPVS=($(pvs --noheadings -o pv_name))\n",
+                "   for PV in \"${LVMPVS[@]}\"\n",
+                "   do\n",
+                "      pvresize ${PV}\n",
+                "   done\n",
+                "\n",
+                "   vgdisplay -s\n",
+                "fi\n",
+                "\n",
                 "# Export AWS ENVs\n",
                 "test -r /etc/aws/models/endpoints.json && export AWS_DATA_PATH=/etc/aws/models || true\n",
                 "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -24,21 +24,47 @@
         { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
       ]
     },
+    "NotGenFive": {
+      "Fn::Not": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                { "Fn::Select": [
+                    "0",
+                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
+                  ]
+                },
+                "c5"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                { "Fn::Select": [
+                    "0",
+                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
+                  ]
+                },
+                "m5"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                { "Fn::Select": [
+                    "0",
+                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
+                  ]
+                },
+                "t3"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "Reboot": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
-      ]
-    },
-    "SupportsNvme": {
-      "Fn::Equals": [
-        {
-          "Fn::FindInMap": [
-            "InstanceTypeMap",
-            { "Ref": "InstanceType" },
-            "SupportsNvme"
-          ]
-        },
-        "true"
       ]
     },
     "UseAdminGroups": {
@@ -149,45 +175,14 @@
   },
   "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
   "Mappings": {
-    "InstanceTypeMap": {
-      "c4.large": {
-        "SupportsNvme": "false"
+    "InstanceTypeCapabilities": {
+      "IsGenFive": {
+        "ExternDeviceName": "/dev/xvdf",
+        "InternDeviceName": "/dev/nvme1n1"
       },
-      "c4.xlarge": {
-        "SupportsNvme": "false"
-      },
-      "c5.large": {
-        "SupportsNvme": "true"
-      },
-      "c5.xlarge": {
-        "SupportsNvme": "true"
-      },
-      "m4.large": {
-        "SupportsNvme": "false"
-      },
-      "m4.xlarge": {
-        "SupportsNvme": "false"
-      },
-      "m5.large": {
-        "SupportsNvme": "true"
-      },
-      "m5.xlarge": {
-        "SupportsNvme": "true"
-      },
-      "t2.large": {
-        "SupportsNvme": "false"
-      },
-      "t2.medium": {
-        "SupportsNvme": "false"
-      },
-      "t2.micro": {
-        "SupportsNvme": "false"
-      },
-      "t2.small": {
-        "SupportsNvme": "false"
-      },
-      "t2.xlarge": {
-        "SupportsNvme": "false"
+      "PreGenFive": {
+        "ExternDeviceName": "/dev/xvdf",
+        "InternDeviceName": "/dev/xvdf"
       }
     }
   },
@@ -291,18 +286,18 @@
       "Description": "Scale Up Scheduled Action ID",
       "Value": { "Ref": "ScaleUpScheduledAction" }
     },
-    "WatchmakerAutoScalingGroupId": {
+    "JenkinsMasterASGId": {
       "Description": "Autoscaling Group ID",
-      "Value": { "Ref": "WatchmakerAutoScalingGroup" }
+      "Value": { "Ref": "JenkinsMasterASG" }
     },
-    "WatchmakerLaunchConfigId": {
+    "JenkinsMasterLCId": {
       "Description": "Launch Configuration ID",
-      "Value": { "Ref": "WatchmakerLaunchConfig" }
+      "Value": { "Ref": "JenkinsMasterLC" }
     },
-    "WatchmakerLaunchConfigLogGroupName": {
+    "JenkinsMasterLCLogGroupName": {
       "Condition": "InstallCloudWatchAgent",
       "Description": "Log Group Name",
-      "Value": { "Ref": "WatchmakerLaunchConfigLogGroup" }
+      "Value": { "Ref": "JenkinsMasterLCLogGroup" }
     }
   },
   "Parameters": {
@@ -615,7 +610,7 @@
     "ScaleDownScheduledAction": {
       "Condition": "UseScheduledAction",
       "Properties": {
-        "AutoScalingGroupName": { "Ref": "WatchmakerAutoScalingGroup" },
+        "AutoScalingGroupName": { "Ref": "JenkinsMasterASG" },
         "DesiredCapacity": { "Ref": "MinCapacity" },
         "Recurrence": { "Ref": "ScaleDownSchedule" }
       },
@@ -624,13 +619,13 @@
     "ScaleUpScheduledAction": {
       "Condition": "UseScheduledAction",
       "Properties": {
-        "AutoScalingGroupName": { "Ref": "WatchmakerAutoScalingGroup" },
+        "AutoScalingGroupName": { "Ref": "JenkinsMasterASG" },
         "DesiredCapacity": { "Ref": "MaxCapacity" },
         "Recurrence": { "Ref": "ScaleUpSchedule" }
       },
       "Type": "AWS::AutoScaling::ScheduledAction"
     },
-    "WatchmakerAutoScalingGroup": {
+    "JenkinsMasterASG": {
       "CreationPolicy": {
         "ResourceSignal": {
           "Count": { "Ref": "DesiredCapacity" },
@@ -653,7 +648,7 @@
             "EC2"
           ]
         },
-        "LaunchConfigurationName": { "Ref": "WatchmakerLaunchConfig" },
+        "LaunchConfigurationName": { "Ref": "JenkinsMasterLC" },
         "LoadBalancerNames": {
           "Fn::If": [
             "UseLoadBalancerNames",
@@ -693,7 +688,7 @@
         }
       }
     },
-    "WatchmakerLaunchConfig": {
+    "JenkinsMasterLC": {
       "Metadata": {
         "AWS::CloudFormation::Init": {
           "admkey-install": {
@@ -876,7 +871,7 @@
                       {
                         "Fn::If": [
                           "InstallCloudWatchAgent",
-                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "JenkinsMasterLCLogGroup" },
                           { "Ref": "AWS::NoValue" }
                         ]
                       },
@@ -890,7 +885,7 @@
                       {
                         "Fn::If": [
                           "InstallCloudWatchAgent",
-                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "JenkinsMasterLCLogGroup" },
                           { "Ref": "AWS::NoValue" }
                         ]
                       },
@@ -904,7 +899,7 @@
                       {
                         "Fn::If": [
                           "InstallCloudWatchAgent",
-                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "JenkinsMasterLCLogGroup" },
                           { "Ref": "AWS::NoValue" }
                         ]
                       },
@@ -918,7 +913,7 @@
                       {
                         "Fn::If": [
                           "InstallCloudWatchAgent",
-                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "JenkinsMasterLCLogGroup" },
                           { "Ref": "AWS::NoValue" }
                         ]
                       },
@@ -932,7 +927,7 @@
                       {
                         "Fn::If": [
                           "InstallCloudWatchAgent",
-                          { "Ref": "WatchmakerLaunchConfigLogGroup" },
+                          { "Ref": "JenkinsMasterLCLogGroup" },
                           { "Ref": "AWS::NoValue" }
                         ]
                       },
@@ -962,7 +957,7 @@
                       "cfn-signal -e 0",
                       " --stack ",
                       { "Ref": "AWS::StackName" },
-                      " --resource WatchmakerAutoScalingGroup",
+                      " --resource JenkinsMasterASG",
                       {
                         "Fn::If": [
                           "AssignInstanceRole",
@@ -1152,11 +1147,11 @@
                     [
                       "[cfn-auto-reloader-hook]\n",
                       "triggers=post.update\n",
-                      "path=Resources.WatchmakerLaunchConfig.Metadata\n",
+                      "path=Resources.JenkinsMasterLC.Metadata\n",
                       "action=cfn-init -v -c update",
                       " --stack ",
                       { "Ref": "AWS::StackName" },
-                      " --resource WatchmakerLaunchConfig",
+                      " --resource JenkinsMasterLC",
                       {
                         "Fn::If": [
                           "AssignInstanceRole",
@@ -1553,9 +1548,21 @@
                           "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
                           {
                             "Fn::If": [
-                              "SupportsNvme",
-                              "/dev/nvme1n1",
-                              "/dev/xvdf"
+                              "NotGenFive",
+                              {
+                                "Fn::FindInMap": [
+                                  "InstanceTypeCapabilities",
+                                  "PreGenFive",
+                                  "InternDeviceName"
+                                ]
+                              },
+                              {
+                                "Fn::FindInMap": [
+                                  "InstanceTypeCapabilities",
+                                  "IsGenFive",
+                                  "InternDeviceName"
+                                ]
+                              }
                             ]
                           },
                           "\n",
@@ -1563,12 +1570,25 @@
                           "- [ ",
                           {
                             "Fn::If": [
-                              "SupportsNvme",
-                              "/dev/nvme1n1",
-                              "/dev/xvdf"
+                              "NotGenFive",
+                              {
+                                "Fn::FindInMap": [
+                                  "InstanceTypeCapabilities",
+                                  "PreGenFive",
+                                  "InternDeviceName"
+                                ]
+                              },
+                              {
+                                "Fn::FindInMap": [
+                                  "InstanceTypeCapabilities",
+                                  "IsGenFive",
+                                  "InternDeviceName"
+                                ]
+                              }
                             ]
                           },
                           ", ",
+
                           { "Ref": "AppVolumeMountPath" },
                           " ]\n"
                         ]
@@ -1608,6 +1628,11 @@
                 "export AWS_DEFAULT_REGION=",
                 { "Ref": "AWS::Region" },
                 "\n\n",
+                "# Add local hostname binding\n",
+                "printf \"%s\\t%s %s\\n\" ",
+                "\"$( ip addr show eth0 | sed -n '/eth0$/p' | sed -e 's/^ *inet *//' -e 's#/.*$##' )\" ",
+                "\"$( hostname -f)\" \"$( hostname -s )\" >> /etc/hosts\n",
+                "\n",
                 "# Get pip\n",
                 "PYPI_URL=",
                 { "Ref": "PypiIndexUrl" },
@@ -1616,6 +1641,14 @@
                 { "Ref": "CfnGetPipUrl" },
                 " | python - --index-url=\"$PYPI_URL\" 'wheel<0.30.0;python_version<\"2.7\"' 'wheel;python_version>=\"2.7\"'",
                 "\n\n",
+                "# Update cfn-bootstrapper hash method\n",
+                "PYVERS=$(python -c 'import sys;",
+                " version=sys.version_info[:2];",
+                " print(\"{0}.{1}\".format(*version))')\n",
+                "sed -i '/^[ \\t][ \\t]*self._etag/s/etag$/None/'",
+                " /usr/lib/python${PYVERS}/site-packages/cfnbootstrap",
+                "/util.py\n",
+                "\n",
                 "# Add pip to path\n",
                 "hash pip 2> /dev/null || ",
                 "PATH=\"${PATH}:/usr/local/bin\"",
@@ -1669,7 +1702,7 @@
                 "cfn-init -v -c launch",
                 " --stack ",
                 { "Ref": "AWS::StackName" },
-                " --resource WatchmakerLaunchConfig",
+                " --resource JenkinsMasterLC",
                 {
                   "Fn::If": [
                     "AssignInstanceRole",
@@ -1707,7 +1740,7 @@
                 " cfn-signal -e 1",
                 "  --stack ",
                 { "Ref": "AWS::StackName" },
-                "  --resource WatchmakerAutoScalingGroup",
+                "  --resource JenkinsMasterASG",
                 {
                   "Fn::If": [
                     "AssignInstanceRole",
@@ -1751,7 +1784,7 @@
       },
       "Type": "AWS::AutoScaling::LaunchConfiguration"
     },
-    "WatchmakerLaunchConfigLogGroup": {
+    "JenkinsMasterLCLogGroup": {
       "Condition": "InstallCloudWatchAgent",
       "Properties": {
         "LogGroupName": {

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -173,7 +173,7 @@
       ]
     }
   },
-  "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
+  "Description": "This template deploys ASG-managed, STIG-hardened Linux instances to host the Jenkins service's master node",
   "Mappings": {
     "InstanceTypeCapabilities": {
       "IsGenFive": {
@@ -795,7 +795,21 @@
                 ]
               },
               "watchmaker-install",
+              {
+                "Fn::If": [
+                  "UseOsPrepScript",
+                  "osprep",
+                  { "Ref" : "AWS::NoValue" }
+                ]
+              },
               "watchmaker-launch",
+              {
+                "Fn::If": [
+                  "UseCfnAppInstaller",
+                  "app-install",
+                  { "Ref" : "AWS::NoValue" }
+                ]
+              },
               "finalize",
               {
                 "Fn::If": [
@@ -815,7 +829,21 @@
                 ]
               },
               "watchmaker-install",
+              {
+                "Fn::If": [
+                  "UseOsPrepScript",
+                  "osprep",
+                  { "Ref" : "AWS::NoValue" }
+                ]
+              },
               "watchmaker-update",
+              {
+                "Fn::If": [
+                  "UseCfnAppInstaller",
+                  "app-install",
+                  { "Ref" : "AWS::NoValue" }
+                ]
+              },
               "finalize",
               {
                 "Fn::If": [

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -12,11 +12,7 @@
       ]
     },
     "CreateAppVolume": {
-      "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "true" ] },
-    "ExecuteAppScript": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] }
-      ]
+      "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "true" ]
     },
     "InstallCloudWatchAgent": {
       "Fn::Not": [
@@ -203,16 +199,6 @@
         },
         {
           "Label": {
-            "default": "EC2 Application Configuration"
-          },
-          "Parameters": [
-            "AppScriptUrl",
-            "AppScriptParams",
-            "AppScriptShell"
-          ]
-        },
-        {
-          "Label": {
             "default": "EC2 Application EBS Volume"
           },
           "Parameters": [
@@ -298,26 +284,6 @@
     "AmiId": {
       "Description": "ID of the AMI to launch",
       "Type": "AWS::EC2::Image::Id"
-    },
-    "AppScriptParams": {
-      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
-      "Type": "String"
-    },
-    "AppScriptShell": {
-      "AllowedValues": [
-        "bash",
-        "python"
-      ],
-      "Default": "bash",
-      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
-      "Type": "String"
-    },
-    "AppScriptUrl": {
-      "AllowedPattern": "^$|^s3://(.*)$",
-      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
-      "Default": "",
-      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
-      "Type": "String"
     },
     "AppVolumeDevice": {
       "AllowedValues": [
@@ -640,13 +606,6 @@
               },
               "watchmaker-install",
               "watchmaker-launch",
-              {
-                "Fn::If": [
-                  "ExecuteAppScript",
-                  "make-app",
-                  { "Ref": "AWS::NoValue" }
-                ]
-              },
               "finalize",
               {
                 "Fn::If": [
@@ -667,13 +626,6 @@
               },
               "watchmaker-install",
               "watchmaker-update",
-              {
-                "Fn::If": [
-                  "ExecuteAppScript",
-                  "make-app",
-                  { "Ref": "AWS::NoValue" }
-                ]
-              },
               "finalize",
               {
                 "Fn::If": [
@@ -873,38 +825,6 @@
             "commands": {
               "10-install-updates": {
                 "command": "yum -y update"
-              }
-            }
-          },
-          "make-app": {
-            "commands": {
-              "05-get-appscript": {
-                "command": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "mkdir -p /etc/cfn/scripts &&",
-                      " aws s3 cp ",
-                      { "Ref": "AppScriptUrl" },
-                      " /etc/cfn/scripts/make-app",
-                      " &&",
-                      " chown root:root /etc/cfn/scripts/make-app &&",
-                      " chmod 700 /etc/cfn/scripts/make-app"
-                    ]
-                  ]
-                }
-              },
-              "10-make-app": {
-                "command": {
-                  "Fn::Join": [
-                    "",
-                    [
-                      { "Ref": "AppScriptShell" },
-                      " /etc/cfn/scripts/make-app ",
-                      { "Ref": "AppScriptParams" }
-                    ]
-                  ]
-                }
               }
             }
           },

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -128,17 +128,6 @@
   },
   "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
   "Mappings": {
-    "Distro2RootDevice": {
-      "AmazonLinux": {
-        "DeviceName": "xvda"
-      },
-      "CentOS": {
-        "DeviceName": "sda1"
-      },
-      "RedHat": {
-        "DeviceName": "sda1"
-      }
-    },
     "InstanceTypeMap": {
       "c4.large": {
         "SupportsNvme": "false"
@@ -190,7 +179,6 @@
           },
           "Parameters": [
             "AmiId",
-            "AmiDistro",
             "InstanceType",
             "InstanceRole",
             "KeyPairName",
@@ -307,15 +295,6 @@
     }
   },
   "Parameters": {
-    "AmiDistro": {
-      "AllowedValues": [
-        "AmazonLinux",
-        "CentOS",
-        "RedHat"
-      ],
-      "Description": "Linux distro of the AMI",
-      "Type": "String"
-    },
     "AmiId": {
       "Description": "ID of the AMI to launch",
       "Type": "AWS::EC2::Image::Id"
@@ -1291,21 +1270,7 @@
         },
         "BlockDeviceMappings": [
           {
-            "DeviceName": {
-              "Fn::Join": [
-                "",
-                [
-                  "/dev/",
-                  {
-                    "Fn::FindInMap": [
-                      "Distro2RootDevice",
-                      { "Ref": "AmiDistro" },
-                      "DeviceName"
-                    ]
-                  }
-                ]
-              ]
-            },
+            "DeviceName": "/dev/sda1",
             "Ebs": {
               "DeleteOnTermination": true,
               "VolumeType": "gp2"

--- a/Templates/make_jenkins_EC2-Master-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-instance.tmplt.json
@@ -259,7 +259,7 @@
     },
     "AppVolumeMountPath": {
       "AllowedPattern": "/.*",
-      "Default": "/opt/data",
+      "Default": "/var/lib/jenkins",
       "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is false",
       "Type": "String"
     },

--- a/Templates/make_jenkins_EC2-Master-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-instance.tmplt.json
@@ -265,7 +265,7 @@
     },
     "AppVolumeSize": {
       "ConstraintDescription": "Must be between 1GB and 16384GB.",
-      "Default": "1",
+      "Default": "20",
       "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is false",
       "MaxValue": "16384",
       "MinValue": "1",


### PR DESCRIPTION
#### Description:

Adds an AutoScaling template (and associated Jenkins pipeline-definition) to the template set. 

#### Rationale:

Increase the resiliency/availability of the Jenkins master by protecting it with a single-instance AutoScaling group.

#### Notes:

1. Tested green in Jenkins
1. Assuming all external dependencies are healthy (*cough* EPEL *cough), ASG-governed failure-detection/rebuild and ELB healthcheck-pass is about 20-minutes given a 15GiB auto-recovery TAR file