### PR TITLE
Add cfn-python-lint Test

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Severity**
+- [ ] Completely Broken (No work-around evident)
+- [ ] Severely Broken (Work-around possible but difficult)
+- [ ] Moderately Broken (Trivial work-around)
+- [ ] Nuisance (Functions but untrapped errors can slip through)
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.
+
+**Fix Suggestions**

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,29 @@
+---
+name: Documentation Request
+about: Create a report to help us improve
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**Documentation Request**
+
+**New doc or update?**
+
+<!-- What is the request-type -->
+
+- [ ] New documentation
+- [ ] Clarify existing documentation
+- [ ] Fix documentation-error
+
+**Documentation blurb**
+
+<!-- Gather some information about what's being requested -->
+
+- Document Name (Existing or Proposed)
+- Document Location (Path within project, etc.)
+    - Current Location
+    - Requested Location (if different from current)
+- Feature **overview/description**
+- Feature **use cases**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what functionality is sought. Ex. I'm used to 'X' functionality being available but it appears to be absent from this automation-set.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,47 @@
-language: shell
+language: bash
+
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-matrix:
+jobs:
   include:
-    - env:
+    - stage: test
+      name: "Shell Syntax-Check"
+      env:
         - TESTENV=shellcheck
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.sh' -type f -print0 | xargs -0 -n1 -t shellcheck"
         - SHELLCHECK_OPTS="-s bash"
-    - env:
+      before_install:
+        - echo $TESTCOMMAND
+        - shellcheck --version
+    - stage: test
+      name: "Template JSON Syntax-Check"
+      env:
         - TESTENV=json-tool
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t jq --exit-status . {} > /dev/null"
-
-before_install:
-  - echo $TESTCOMMAND
-  - shellcheck --version
-
-install:
-  # Download json parser
-  - curl -sO http://stedolan.github.io/jq/download/linux64/jq
-  - chmod +x $PWD/jq
+      install:
+        # Download json parser
+        - curl -sO http://stedolan.github.io/jq/download/linux64/jq
+        - chmod +x $PWD/jq
+    - stage: test
+      name: "Template CFn Syntax-Check"
+      language: python
+      python: 3.6
+      env:
+        - TESTENV=cfn-lint
+        # E1029: Because it chokes on BASH vars in 'content' blocks
+        # E2015: Because can't identify why it's failing on the test (relevant content is valid)
+        - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t cfn-lint -i E1029,E2015 -t {} > /dev/null"
+      install:
+        - pip install cfn-lint
 
 script:
   - bash -c "$TESTCOMMAND"
+
+stages:
+  - test
 
 notifications:
   email:

--- a/Templates/deprecated/make_jenkins_EC2-autoscale.tmplt.json
+++ b/Templates/deprecated/make_jenkins_EC2-autoscale.tmplt.json
@@ -195,8 +195,6 @@
           },
           "Parameters": [
             "CfnEndpointUrl",
-            "CfnGetPipUrl",
-            "CfnBootstrapUtilsUrl",
             "ToggleCfnInitUpdate",
             "ToggleNewInstances"
           ]
@@ -221,7 +219,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "AppVolumeDevice": {
       "AllowedValues": [
@@ -272,22 +270,10 @@
       "Description": "Folder in S3 Bucket to host backups of Jenkins config-data",
       "Type": "String"
     },
-    "CfnBootstrapUtilsUrl": {
-      "AllowedPattern": "^$|^http[s]?://.*\\.tar\\.gz$",
-      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
-      "Type": "String"
-    },
     "CfnEndpointUrl": {
       "AllowedPattern": "^$|^http[s]?://.*$",
       "Default": "https://cloudformation.us-east-1.amazonaws.com",
       "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-      "Type": "String"
-    },
-    "CfnGetPipUrl": {
-      "AllowedPattern": "^$|^http[s]?://.*\\.py$",
-      "Default": "https://bootstrap.pypa.io/get-pip.py",
-      "Description": "URL to get-pip.py",
       "Type": "String"
     },
     "DesiredCapacity": {
@@ -520,7 +506,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "PropagateAtLaunch": "true",
+            "PropagateAtLaunch": true,
             "Value": {
               "Fn::Join": [
                 "",
@@ -536,10 +522,10 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": "2",
-          "MinInstancesInService": "1",
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
           "PauseTime": "PT60M",
-          "WaitOnResourceSignals": "true"
+          "WaitOnResourceSignals": true
         }
       }
     },
@@ -1197,15 +1183,15 @@
         "AssociatePublicIpAddress": {
           "Fn::If": [
             "AssignPublicIp",
-            "true",
-            "false"
+            true,
+            false
           ]
         },
         "BlockDeviceMappings": [
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "DeleteOnTermination": "true",
+              "DeleteOnTermination": true,
               "VolumeType": "gp2"
             }
           },
@@ -1233,7 +1219,7 @@
                   ]
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": { "Ref": "AppVolumeSize" },
                   "VolumeType": { "Ref": "AppVolumeType" }
                 }

--- a/Templates/deprecated/make_jenkins_EC2-instance.tmplt.json
+++ b/Templates/deprecated/make_jenkins_EC2-instance.tmplt.json
@@ -16,11 +16,6 @@
         { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] }
       ]
     },
-    "InstallUpdates": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
-      ]
-    },
     "Reboot": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
@@ -70,7 +65,6 @@
             "ProvisionUser",
             "KeyPairName",
             "NoReboot",
-            "NoUpdates",
             "SecurityGroupIds"
           ]
         },
@@ -102,7 +96,6 @@
           },
           "Parameters": [
             "BackupBucket",
-            "BackupCronURL",
             "BackupFolder"
           ]
         },
@@ -126,12 +119,7 @@
             "CfnEndpointUrl"
           ]
         }
-      ],
-      "ParameterLabels": {
-        "ForceNewInstancesToggle": {
-          "default": "Force New Instances"
-        }
-      }
+      ]
     }
   },
   "Outputs": {
@@ -161,7 +149,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "AppVolumeDevice": {
       "AllowedValues": [
@@ -205,11 +193,6 @@
     "BackupBucket": {
       "AllowedPattern": "^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]*$|^$",
       "Description": "S3 Bucket to host backups of Jenkins config-data",
-      "Type": "String"
-    },
-    "BackupCronURL": {
-      "AllowedPattern": "^$|^http://.*$|^https://.*$",
-      "Description": "URL to the Jenkins backup cron-file",
       "Type": "String"
     },
     "BackupFolder": {
@@ -305,15 +288,6 @@
       ],
       "Default": "false",
       "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
-      "Type": "String"
-    },
-    "NoUpdates": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, SystemPrep _always_ installs updates)",
       "Type": "String"
     },
     "PipIndexFips": {
@@ -809,7 +783,7 @@
               ]
             },
             "Ebs": {
-              "DeleteOnTermination": "true",
+              "DeleteOnTermination": true,
               "VolumeType": "gp2"
             }
           },
@@ -819,7 +793,7 @@
               {
                 "DeviceName": { "Ref": "AppVolumeDevice" },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": { "Ref": "AppVolumeSize" },
                   "VolumeType": { "Ref": "AppVolumeType" }
                 }
@@ -843,8 +817,8 @@
             "AssociatePublicIpAddress": {
               "Fn::If": [
                 "AssignPublicIp",
-                "true",
-                "false"
+                true,
+                false
               ]
             },
             "DeviceIndex": "0",

--- a/Templates/deprecated/make_jenkins_ELBv1-pub.tmplt.json
+++ b/Templates/deprecated/make_jenkins_ELBv1-pub.tmplt.json
@@ -123,7 +123,7 @@
         "ConnectionSettings": {
           "IdleTimeout": { "Ref": "BackendTimeout" }
         },
-        "CrossZone": "true",
+        "CrossZone": true,
         "HealthCheck": {
           "HealthyThreshold": "5",
           "Interval": "30",

--- a/Templates/make_jenkins_EC2-Agent-Linux-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Agent-Linux-autoscale.tmplt.json
@@ -184,7 +184,6 @@
           },
           "Parameters": [
             "CfnEndpointUrl",
-            "CfnGetPipUrl",
             "ToggleCfnInitUpdate",
             "ToggleNewInstances"
           ]
@@ -228,7 +227,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "AppVolumeDevice": {
       "AllowedValues": [
@@ -269,12 +268,6 @@
       "AllowedPattern": "^$|^http[s]?://.*$",
       "Default": "https://cloudformation.us-east-1.amazonaws.com",
       "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-      "Type": "String"
-    },
-    "CfnGetPipUrl": {
-      "AllowedPattern": "^http[s]?://.*\\.py$",
-      "Default": "https://bootstrap.pypa.io/get-pip.py",
-      "Description": "URL to get-pip.py",
       "Type": "String"
     },
     "ChainScriptUrl": {
@@ -521,7 +514,7 @@
         "Tags": [
           {
             "Key": "Name",
-            "PropagateAtLaunch": "true",
+            "PropagateAtLaunch": true,
             "Value": {
               "Fn::Join": [
                 "",
@@ -537,10 +530,10 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingRollingUpdate": {
-          "MaxBatchSize": "2",
-          "MinInstancesInService": "1",
+          "MaxBatchSize": 2,
+          "MinInstancesInService": 1,
           "PauseTime": "PT30M",
-          "WaitOnResourceSignals": "true"
+          "WaitOnResourceSignals": true
         }
       }
     },
@@ -1324,8 +1317,8 @@
         "AssociatePublicIpAddress": {
           "Fn::If": [
             "AssignPublicIp",
-            "true",
-            "false"
+            true,
+            false
           ]
         },
         "BlockDeviceMappings": [
@@ -1361,7 +1354,7 @@
                   ]
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": { "Ref": "AppVolumeSize" },
                   "VolumeType": { "Ref": "AppVolumeType" }
                 }

--- a/Templates/make_jenkins_EC2-Agent-Linux-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-Agent-Linux-instance.tmplt.json
@@ -11,19 +11,9 @@
         { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] }
       ]
     },
-    "AssignStaticPrivateIp": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "PrivateIp" }, "" ] }
-      ]
-    },
     "CreateAppVolume": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] }
-      ]
-    },
-    "InstallUpdates": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
       ]
     },
     "NotGenFive": {
@@ -52,11 +42,6 @@
             }
           ]
         }
-      ]
-    },
-    "Reboot": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
       ]
     },
     "UseCfnUrl": {
@@ -111,10 +96,7 @@
             "AdminPubkeyURL",
             "SecurityGroupIds",
             "SubnetId",
-            "PrivateIp",
-            "NoPublicIp",
-            "NoReboot",
-            "NoUpdates"
+            "NoPublicIp"
           ]
         },
         {
@@ -176,7 +158,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "AppVolumeDevice": {
       "AllowedValues": [
@@ -312,32 +294,9 @@
       "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
       "Type": "String"
     },
-    "NoReboot": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
-      "Type": "String"
-    },
-    "NoUpdates": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
-      "Type": "String"
-    },
     "PipRpm": {
       "Default": "python2-pip",
       "Description": "Name of preferred pip RPM.",
-      "Type": "String"
-    },
-    "PrivateIp": {
-      "Default": "",
-      "Description": "(Optional) Set a static, primary private IP. Leave blank to auto-select a free IP",
       "Type": "String"
     },
     "ProvisionUser": {
@@ -789,8 +748,8 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": "20",
+              "DeleteOnTermination": true,
+              "VolumeSize": 20,
               "VolumeType": "gp2"
             }
           },
@@ -818,7 +777,7 @@
                   ]
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": { "Ref": "AppVolumeSize" },
                   "VolumeType": { "Ref": "AppVolumeType" }
                 }
@@ -849,8 +808,8 @@
             "AssociatePublicIpAddress": {
               "Fn::If": [
                 "AssignPublicIp",
-                "true",
-                "false"
+                true,
+                false
               ]
             },
             "GroupSet": { "Ref": "SecurityGroupIds" },

--- a/Templates/make_jenkins_EC2-Agent-Windows-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-Agent-Windows-instance.tmplt.json
@@ -195,7 +195,6 @@
                     },
                     "Parameters": [
                         "AmiId",
-                        "AppVolumeMountPath",
                         "AppVolumeSize",
                         "AppVolumeType",
                         "InstanceType",
@@ -203,8 +202,6 @@
                         "KeyPairName",
                         "NoPublicIp",
                         "NoReboot",
-                        "NoUpdates",
-                        "PipIndexFips",
                         "SecurityGroupIds",
                         "SubnetId"
                     ]

--- a/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-autoscale.tmplt.json
@@ -72,11 +72,6 @@
         { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] }
       ]
     },
-    "UseAdminPubkeyURL": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "AdminPubkeyURL" }, "" ] }
-      ]
-    },
     "UseAdminUsers": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] }
@@ -96,11 +91,6 @@
       "Fn::Or": [
         { "Condition": "UseLoadBalancerNames" },
         { "Condition": "UseTargetGroupArns" }
-      ]
-    },
-    "UseComputerName": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "WatchmakerComputerName" }, "" ] }
       ]
     },
     "UseEnvironment": {
@@ -702,7 +692,7 @@
       "Type": "AWS::AutoScaling::AutoScalingGroup",
       "UpdatePolicy": {
         "AutoScalingReplacingUpdate": {
-          "WillReplace": "true"
+          "WillReplace": true
         }
       }
     },

--- a/Templates/make_jenkins_EC2-Master-instance.tmplt.json
+++ b/Templates/make_jenkins_EC2-Master-instance.tmplt.json
@@ -1390,7 +1390,7 @@
                   ]
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": { "Ref": "AppVolumeSize" },
                   "VolumeType": { "Ref": "AppVolumeType" }
                 }

--- a/Templates/make_jenkins_ELBv1-pub-autoscale.tmplt.json
+++ b/Templates/make_jenkins_ELBv1-pub-autoscale.tmplt.json
@@ -125,7 +125,7 @@
         "ConnectionSettings": {
           "IdleTimeout": { "Ref": "BackendTimeout" }
         },
-        "CrossZone": "true",
+        "CrossZone": true,
         "HealthCheck": {
           "HealthyThreshold": "5",
           "Interval": "30",

--- a/Templates/make_jenkins_ELBv2-pub.tmplt.json
+++ b/Templates/make_jenkins_ELBv2-pub.tmplt.json
@@ -23,9 +23,7 @@
             "SecurityGroupIds",
             "JenkinsListenPort",
             "JenkinsServicePort",
-            "JenkinsAgentPort",
-            "JenkinsListenerCert",
-            "BackendTimeout"
+            "JenkinsListenerCert"
           ]
         }
       ]
@@ -63,19 +61,6 @@
     }
   },
   "Parameters": {
-    "BackendTimeout": {
-      "Default": "600",
-      "Description": "How long - in seconds - back-end connection may be idle before attempting session-cleanup",
-      "MinValue": "60",
-      "MaxValue": "3600",
-      "Type": "Number"
-    },
-    "JenkinsAgentPort": {
-      "Description": "TCP Port number that the Jenkins agent-hosts connect through.",
-      "MaxValue": "65535",
-      "MinValue": "1025",
-      "Type": "Number"
-    },
     "JenkinsListenerCert": {
       "Default": "",
       "Description": "Name/ID of the ACM-managed SSL Certificate to protect public listener.",
@@ -173,7 +158,7 @@
     "JenkinsPubAlbTgroup": {
       "Properties": {
         "HealthCheckPath": "/ELBtest.txt",
-        "HealthyThresholdCount": "5",
+        "HealthyThresholdCount": 5,
         "Name": {
           "Fn::Join": [
             "-",
@@ -203,7 +188,7 @@
             "Value" : "true"
           }
         ],
-        "UnhealthyThresholdCount": "2",
+        "UnhealthyThresholdCount": 2,
         "VpcId": { "Ref": "TargetVPC" }
       },
       "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup"

--- a/Templates/make_jenkins_SGs.tmplt.json
+++ b/Templates/make_jenkins_SGs.tmplt.json
@@ -32,9 +32,9 @@
           {
             "CidrIp": "0.0.0.0/0",
             "Description": "SSL-protected web-interface connections",
-            "FromPort": "443",
+            "FromPort": 443,
             "IpProtocol": "tcp",
-            "ToPort": "443"
+            "ToPort": 443
           },
           {
             "CidrIp": "0.0.0.0/0",
@@ -57,10 +57,9 @@
       "Type": "AWS::EC2::SecurityGroup"
     },
     "UpdateAppSg": {
-      "DependsOn": "AppSg",
       "Properties": {
         "Description": "Comms between service-elements",
-        "FromPort": "0",
+        "FromPort": 0,
         "GroupId": {
           "Ref": "AppSg"
         },
@@ -68,7 +67,7 @@
         "SourceSecurityGroupId": {
           "Ref": "AppSg"
         },
-        "ToPort": "65535"
+        "ToPort": 65535
       },
       "Type": "AWS::EC2::SecurityGroupIngress"
     }

--- a/Templates/make_jenkins_infra.tmplt.json
+++ b/Templates/make_jenkins_infra.tmplt.json
@@ -30,7 +30,6 @@
             "CloudwatchBucketName",
             "TargetVPC",
             "JenkinsAgentPort",
-            "ServiceTld",
             "RolePrefix"
           ]
         }
@@ -127,11 +126,6 @@
       "Description": "URL to the child-template for creating the Jenkins network security-groups.",
       "Type": "String"
     },
-    "ServiceTld": {
-      "Default": "amazonaws.com",
-      "Description": "TLD of the IAMable service-name.",
-      "Type": "String"
-    },
     "TargetVPC": {
       "AllowedPattern": "^vpc-[0-9a-f]*$",
       "Description": "ID of the VPC to deploy Jenkins components into.",
@@ -149,7 +143,7 @@
           "RolePrefix": { "Ref": "RolePrefix" }
         },
         "TemplateURL": { "Ref": "IamRoleTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -165,7 +159,7 @@
           }
         },
         "TemplateURL": { "Ref": "BucketTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -176,7 +170,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_jenkins_parent-autoscale.tmplt.json
+++ b/Templates/make_jenkins_parent-autoscale.tmplt.json
@@ -28,7 +28,6 @@
             "ProvisionUser",
             "KeyPairName",
             "AdminPubkeyURL",
-            "SubnetId",
             "NoPublicIp",
             "AppVolumeDevice",
             "AppVolumeMountPath",
@@ -68,13 +67,11 @@
             "JenkinsListenerCert"
           ]
         },
-            "ServiceTld",
         {
           "Label": {
             "default": "Miscellaneous"
           },
           "Parameters": [
-            "ServiceTld",
             "TargetVPC",
             "RolePrefix"
           ]
@@ -381,11 +378,6 @@
       "Description": "Suffix for Jenkins' hostname and DNS record",
       "Type": "String"
     },
-    "ServiceTld": {
-      "Default": "amazonaws.com",
-      "Description": "TLD of the IAMable service-name.",
-      "Type": "String"
-    },
     "TargetVPC": {
       "AllowedPattern": "^vpc-[0-9a-f]*$",
       "Description": "ID of the VPC to deploy Jenkins components into.",
@@ -445,7 +437,7 @@
               [
                 "https://cloudformation",
                 { "Ref": "AWS::Region" },
-                { "Ref": "ServiceTld" }
+                { "Ref": "AWS::URLSuffix" }
               ]
             ]
           },
@@ -532,10 +524,10 @@
             "Fn::GetAtt": [ "S3Res", "Outputs.JenkinsBucketArn" ]
           },
           "RolePrefix": { "Ref": "RolePrefix" },
-          "ServiceTld": { "Ref": "ServiceTld" }
+          "ServiceTld": { "Ref": "AWS::URLSuffix" }
         },
         "TemplateURL": { "Ref": "IamRoleTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -545,7 +537,7 @@
           "JenkinsBackupBucket": { "Ref": "JenkinsBackupBucket" }
         },
         "TemplateURL": { "Ref": "BucketTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -556,7 +548,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_jenkins_parent-instance.tmplt.json
+++ b/Templates/make_jenkins_parent-instance.tmplt.json
@@ -22,10 +22,7 @@
           },
           "Parameters": [
             "AmiId",
-            "AmiDistro",
             "InstanceType",
-            "ServerHostname",
-            "DnsSuffix",
             "ProvisionUser",
             "KeyPairName",
             "AdminPubkeyURL",
@@ -37,10 +34,7 @@
             "AppVolumeType",
             "NoUpdates",
             "NoReboot",
-            "EpelRepo",
-            "PyStache",
-            "PipRpm",
-            "PipIndexFips"
+            "EpelRepo"
           ]
         },
         {
@@ -53,8 +47,7 @@
             "JenkinsOsPrepScriptUrl",
             "JenkinsAppinstallScriptUrl",
             "BackupBucket",
-            "BackupFolder",
-            "BackupCronURL"
+            "BackupFolder"
           ]
         },
         {
@@ -209,32 +202,8 @@
       "Description": "URL to the child-template for creating the Jenkins S3 backup-bucket.",
       "Type": "String"
     },
-    "CfnBootstrapUtilsUrl": {
-      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
-      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
-      "Type": "String"
-    },
-    "CfnEndpointUrl": {
-      "AllowedPattern": "^$|^http[s]?://.*$",
-      "Default": "https://cloudformation.us-east-1.amazonaws.com",
-      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-      "Type": "String"
-    },
-    "CfnGetPipUrl": {
-      "AllowedPattern": "^http[s]?://.*\\.py$",
-      "Default": "https://bootstrap.pypa.io/2.6/get-pip.py",
-      "Description": "URL to get-pip.py",
-      "Type": "String"
-    },
     "CloudwatchBucketName": {
       "Description": "Name of the S3 Bucket hosting the CloudWatch agent archive files",
-      "Type": "String"
-    },
-    "CloudWatchAgentUrl": {
-      "AllowedPattern": "^$|^s3://.*$",
-      "Default": "",
-      "Description": "(Optional) S3 URL to CloudWatch Agent installer. Example: s3://amazoncloudwatch-agent/linux/amd64/latest/AmazonCloudWatchAgent.zip",
       "Type": "String"
     },
     "Ec2Template": {
@@ -407,14 +376,6 @@
       "Description": "Prefix to apply to IAM role to make things a bit prettier (optional).",
       "Type": "String"
     },
-    "RootVolumeSize": {
-      "ConstraintDescription": "Must be between 20GB and 16384GB.",
-      "Default": "20",
-      "Description": "Size in GB of the EBS volume to create. If smaller than AMI defaul, create operation will fail; If larger, root device-volume's partition size will be increased",
-      "MaxValue": "16384",
-      "MinValue": "20",
-      "Type": "Number"
-    },
     "SecurityGroupTemplate": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
       "Description": "URL to the child-template for creating the Jenkins network security-groups.",
@@ -428,15 +389,6 @@
       "AllowedPattern": "^vpc-[0-9a-f]*$",
       "Description": "ID of the VPC to deploy Jenkins components into.",
       "Type": "AWS::EC2::VPC::Id"
-    },
-    "ToggleCfnInitUpdate": {
-      "AllowedValues": [
-        "A",
-        "B"
-      ],
-      "Default": "A",
-      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
-      "Type": "String"
     },
     "WatchmakerAdminGroups": {
       "Default": "",
@@ -575,7 +527,7 @@
           "RolePrefix": { "Ref": "RolePrefix" }
         },
         "TemplateURL": { "Ref": "IamRoleTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -585,7 +537,7 @@
           "JenkinsBackupBucket": { "Ref": "BackupBucket" }
         },
         "TemplateURL": { "Ref": "BucketTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -596,7 +548,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SecurityGroupTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }


### PR DESCRIPTION
#### Description:

Adds [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) to validation test-set

#### Rationale:

Adding cfn-python-lint to test-set better ensure thats CFn templates are _fucntional_ &mdash; in addition to simply being valid JSON (as performed by previously-existing `jq`-based test)

#### Additional

- Lint the templates already in project so that new test will pass.
- Reorganize `.travis.yml` content