### PR TITLE
Minor Spiffs 

### DIFF
--- a/Deployment/Jenkins/agent/EC2-Linux-instance.groovy
+++ b/Deployment/Jenkins/agent/EC2-Linux-instance.groovy
@@ -217,10 +217,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-Ec2Res-${BUILD_NUMBER} stacks... "
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Ec2Res-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-Ec2Res stacks... "
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Ec2Res"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Ec2Res-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Ec2Res --region ${AwsRegion}
                     '''
                 }
             }
@@ -237,13 +237,13 @@ pipeline {
                         printf 'export SIGNED_URL="%s"' "\$( aws s3 presign ${ChainScriptUrl} )" > /tmp/SIGNED_URL.txt
                         source /tmp/SIGNED_URL.txt
                         printenv | sort
-                        echo "Attempting to create stack ${CfnStackRoot}-Ec2Res-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Ec2Res-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-Ec2Res..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Ec2Res" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-url "${TemplateUrl}" \
                           --parameters file://<( sed "s#__SIGNED_URL__#${SIGNED_URL//&/\\&}#" agent.instance.parms.json )
 
-                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Ec2Res-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Ec2Res --region ${AwsRegion}
                     '''
                 }
             }

--- a/Deployment/Jenkins/master/EC2-Autoscale.groovy
+++ b/Deployment/Jenkins/master/EC2-Autoscale.groovy
@@ -278,10 +278,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} stacks..."
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-AsgRes stacks..."
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-AsgRes"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-AsgRes --region ${AwsRegion}
                     '''
                 }
             }
@@ -294,8 +294,8 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to create stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-AsgRes..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-AsgRes" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-url "${TemplateUrl}" \
                           --parameters file://Jenkins-Ec2-Master-ASG.parms.json
@@ -304,19 +304,19 @@ pipeline {
                         # Pause if create is slow
                         while [[ $(
                                     aws cloudformation describe-stacks \
-                                      --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                      --stack-name ${CfnStackRoot}-AsgRes \
                                       --query 'Stacks[].{Status:StackStatus}' \
                                       --out text 2> /dev/null | \
                                     grep -q CREATE_IN_PROGRESS
                                    )$? -eq 0 ]]
                         do
-                           echo "Waiting for stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} to finish create process..."
+                           echo "Waiting for stack ${CfnStackRoot}-AsgRes to finish create process..."
                            sleep 30
                         done
 
                         if [[ $(
                                 aws cloudformation describe-stacks \
-                                  --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                  --stack-name ${CfnStackRoot}-AsgRes \
                                   --query 'Stacks[].{Status:StackStatus}' \
                                   --out text 2> /dev/null | \
                                 grep -q CREATE_COMPLETE

--- a/Deployment/Jenkins/master/EC2-Instance.groovy
+++ b/Deployment/Jenkins/master/EC2-Instance.groovy
@@ -245,10 +245,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER} stacks..."
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-Ec2Inst stacks..."
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Ec2Inst"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Ec2Inst --region ${AwsRegion}
                     '''
                 }
             }
@@ -262,13 +262,13 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to create stack ${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-Ec2Inst..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Ec2Inst" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-url "${TemplateUrl}" \
                           --parameters file://master.ec2.instance.parms.json
 
-                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Ec2Inst --region ${AwsRegion}
                     '''
                 }
             }
@@ -281,9 +281,9 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "retrieving instance ID for ${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER}..."
+                        echo "retrieving instance ID for ${CfnStackRoot}-Ec2Inst..."
 
-                        InstanceId=$(aws ec2 describe-instances --filters "Name=tag:Name, Values=${CfnStackRoot}-Ec2Inst-${BUILD_NUMBER}" --query "Reservations[].Instances[].InstanceId[]" --output text)
+                        InstanceId=$(aws ec2 describe-instances --filters "Name=tag:Name, Values=${CfnStackRoot}-Ec2Inst" --query "Reservations[].Instances[].InstanceId[]" --output text)
 
                         echo "Attaching ${InstanceId} to ${ElbName}..."
 

--- a/Deployment/Jenkins/master/Infra-layers.groovy
+++ b/Deployment/Jenkins/master/Infra-layers.groovy
@@ -93,10 +93,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-Infra-${BUILD_NUMBER} stacks... "
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Infra-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-Infra stacks... "
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-Infra"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Infra-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-Infra --region ${AwsRegion}
                     '''
                 }
             }
@@ -110,13 +110,13 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to create stack ${CfnStackRoot}-Infra-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Infra-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-Infra..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-Infra" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-body file://Templates/make_jenkins_infra.tmplt.json \
                           --parameters file://service-infra.parms.json
 
-                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Infra-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-Infra --region ${AwsRegion}
                     '''
                 }
             }

--- a/Deployment/Jenkins/master/Master-Ec2-Autosacle.groovy
+++ b/Deployment/Jenkins/master/Master-Ec2-Autosacle.groovy
@@ -278,10 +278,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} stacks..."
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-AsgRes stacks..."
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-AsgRes"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-AsgRes --region ${AwsRegion}
                     '''
                 }
             }
@@ -294,8 +294,8 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to create stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-AsgRes-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-AsgRes..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-AsgRes" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-url "${TemplateUrl}" \
                           --parameters file://Jenkins-Ec2-Master-ASG.parms.json
@@ -304,19 +304,19 @@ pipeline {
                         # Pause if create is slow
                         while [[ $(
                                     aws cloudformation describe-stacks \
-                                      --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                      --stack-name ${CfnStackRoot}-AsgRes \
                                       --query 'Stacks[].{Status:StackStatus}' \
                                       --out text 2> /dev/null | \
                                     grep -q CREATE_IN_PROGRESS
                                    )$? -eq 0 ]]
                         do
-                           echo "Waiting for stack ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} to finish create process..."
+                           echo "Waiting for stack ${CfnStackRoot}-AsgRes to finish create process..."
                            sleep 30
                         done
 
                         if [[ $(
                                 aws cloudformation describe-stacks \
-                                  --stack-name ${CfnStackRoot}-AsgRes-${BUILD_NUMBER} \
+                                  --stack-name ${CfnStackRoot}-AsgRes \
                                   --query 'Stacks[].{Status:StackStatus}' \
                                   --out text 2> /dev/null | \
                                 grep -q CREATE_COMPLETE

--- a/Deployment/Jenkins/master/Master-Elbv1.groovy
+++ b/Deployment/Jenkins/master/Master-Elbv1.groovy
@@ -100,10 +100,10 @@ stages {
                 ]
             ) {
                 sh '''#!/bin/bash
-                    echo "Attempting to delete any active ${CfnStackRoot}-ELbv1-${BUILD_NUMBER} stacks... "
-                    aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-ELbv1-${BUILD_NUMBER}"
+                    echo "Attempting to delete any active ${CfnStackRoot}-ELbv1 stacks... "
+                    aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-ELbv1"
 
-                    aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-ELbv1-${BUILD_NUMBER} --region ${AwsRegion}
+                    aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-ELbv1 --region ${AwsRegion}
                 '''
             }
         }
@@ -117,13 +117,13 @@ stages {
                 ]
             ) {
                 sh '''#!/bin/bash
-                    echo "Attempting to create stack ${CfnStackRoot}-ELbv1-${BUILD_NUMBER}..."
-                    aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-ELbv1-${BUILD_NUMBER}" \
+                    echo "Attempting to create stack ${CfnStackRoot}-ELbv1..."
+                    aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-ELbv1" \
                       --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                       --template-url "${TemplateUrl}" \
                       --parameters file://master.ec2.instance.parms.json
 
-                    aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-ELbv1-${BUILD_NUMBER} --region ${AwsRegion}
+                    aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-ELbv1 --region ${AwsRegion}
                 '''
             }
         }

--- a/Deployment/Jenkins/master/Parent-Full-Instance.groovy
+++ b/Deployment/Jenkins/master/Parent-Full-Instance.groovy
@@ -107,10 +107,10 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to delete any active ${CfnStackRoot}-ParInst-${BUILD_NUMBER} stacks... "
-                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-ParInst-${BUILD_NUMBER}"
+                        echo "Attempting to delete any active ${CfnStackRoot}-ParInst stacks... "
+                        aws --region "${AwsRegion}" cloudformation delete-stack --stack-name "${CfnStackRoot}-ParInst"
 
-                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-ParInst-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-delete-complete --stack-name ${CfnStackRoot}-ParInst --region ${AwsRegion}
                     '''
                 }
             }
@@ -127,13 +127,13 @@ pipeline {
                     ]
                 ) {
                     sh '''#!/bin/bash
-                        echo "Attempting to create stack ${CfnStackRoot}-ParInst-${BUILD_NUMBER}..."
-                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-ParInst-${BUILD_NUMBER}" \
+                        echo "Attempting to create stack ${CfnStackRoot}-ParInst..."
+                        aws --region "${AwsRegion}" cloudformation create-stack --stack-name "${CfnStackRoot}-ParInst" \
                           --disable-rollback --capabilities CAPABILITY_NAMED_IAM \
                           --template-url "${TemplateUrl}" \
                           --parameters file://parent.instance.parms.json
 
-                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-ParInst-${BUILD_NUMBER} --region ${AwsRegion}
+                        aws cloudformation wait stack-create-complete --stack-name ${CfnStackRoot}-ParInst --region ${AwsRegion}
                     '''
                 }
             }

--- a/Templates/make_jenkins_EC2-Agent-Linux-autoscale.tmplt.json
+++ b/Templates/make_jenkins_EC2-Agent-Linux-autoscale.tmplt.json
@@ -581,7 +581,7 @@
           "chain-script": {
             "commands": {
               "1-run-chain-script": {
-                "command": "bash -e /etc/cfn/scripts/chain-script"
+                "command": "bash -xe /etc/cfn/scripts/chain-script"
               }
             },
             "files": {


### PR DESCRIPTION
#### Description:

Make minor spiffs so that resulting Jenkins job-outputs are less annoying

#### Rationale:

Adding `-${BUILDER_NUMBER}` to all the stack-names seemed like a Good Idea&trade;, at the time, but turned into kind of a pain in the ass when used outside of a purely-testing scope.