### PR TITLE
Deployment guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,18 @@ See the `docs` subdirectory. It currently contains the following documents:
 * [ProjectLayout.md](docs/ProjectLayout.md): Describes the overall layout for this git project.
 * Automated Deployment with AWS Native Tooling: Collection of documents describing using (primarily) the AWS CLI to directly-deploy CloudFormation stacks from this project's templates.
     * Master Server Elements
-        * [SecurityGroup-Deployment-AWSnative.md](docs/SecurityGroup-Deployment-AWSnative.md)
-        * [S3-Deployment-AWSnative.md](docs/S3-Deployment-AWSnative.md)
-        * [IAM-Deployment-AWSnative.md](docs/IAM-Deployment-AWSnative.md)
-        * [ELBv1-Deployment-AWSnative.md](docs/ELBv1-Deployment-AWSnative.md)
-        * [Master-Deployment-AWSnative.md](docs/Master-Deployment-AWSnative.md)
-        * [OneButtonMasterDeployment-AWSnative.md](docs/OneButtonMasterDeployment-AWSnative.md)
+        * Consolidated Deployment
+            * ["Fresh" Deployment](docs/Deployment-Fresh.md)
+            * [Upgrade "In Place"](docs/Deployment-Upgrade_InPlace-OS.md) - OS/AMI/Instance-only
+            * [Upgrade "In Place"](docs/Deployment-Upgrade_InPlace-Service.md) - Jenkins Service
+            * [Parallel Upgrade](docs/Deployment-Upgrade_Parallel.md) - OS and/or Jenkins Service
+        * "Template-at-a-time" Deployment
+            * [SecurityGroup-Deployment-AWSnative.md](docs/SecurityGroup-Deployment-AWSnative.md)
+            * [S3-Deployment-AWSnative.md](docs/S3-Deployment-AWSnative.md)
+            * [IAM-Deployment-AWSnative.md](docs/IAM-Deployment-AWSnative.md)
+            * [ELBv1-Deployment-AWSnative.md](docs/ELBv1-Deployment-AWSnative.md)
+            * [Master-Deployment-AWSnative.md](docs/Master-Deployment-AWSnative.md)
+            * [OneButtonMasterDeployment-AWSnative.md](docs/OneButtonMasterDeployment-AWSnative.md)
     * Agent Server Elements
         * [Agent-Linux-Deployment-AWSnative.md](docs/Agent-Linux-Deployment-AWSnative.md)
         * [Agent-Windows-Deployment-AWSnative.md](docs/Agent-Windows-Deployment-AWSnative.md)

--- a/docs/Deployment-Fresh.md
+++ b/docs/Deployment-Fresh.md
@@ -1,0 +1,101 @@
+# Deploying a Wholly-New Jenkins Service - Master Node
+
+## Purpose
+
+This document is intended to walk the automation-user through the process of deploying a brand-new Jenkins service from the templates included in this project.
+
+## Dependencies
+
+In order to use these templates, the following things will be necessary:
+
+* Access to an AWS account
+* An IAM user or role with (at least) enough permissions to:
+    * Create EC2 network security groups
+    * Create S3 buckets
+    * Create classic Elastic LoadBalancers (ELBs)
+    * Create IAM instance-roles and policies
+    * Create RDS databases
+    * Create EFS shares (Optional: only required if deploying to an EFS-supporting region and choosing to use EFS for persistent storage)
+    * Create CloudWatch Logs log-groups (Optional: only required if deploying to a region that supports the use of the CloudWatch Logs service and wishing to take advantage of same)
+    * Create new DNS records in Route53 (Optional: only required if deploying to a region that supports Route53 and use of Route53 DNS service is desired)
+* Access to a computer that has a modern git client
+* Access to a computer that has Python installed (and is pip-enabled)
+* Access to a computer that has a modern web browser
+* Access to a computer that has the AWS CLI installed or _installable_ (e.g., `pip install awscli`)
+* Ability to configure the AWS CLI to use the previously-described IAM user or role
+
+## Automation Elements
+
+The automation in this project works at two levels: cloud-level (AWS components) and instance-level
+
+### Cloud-Level Automation
+
+This project includes a number of CloudFormation templates. These templates are used to deploy AWS resources.
+The templates' functionalities are described in greater detail elsewhere in this documentation-directory.
+
+#### Directly-Used Templates
+
+The following templates are categorized as "directly-used" as they are the templates that automation-users will directly-launch using either the `cloudformation` CLI or web UI:
+
+* `make_jenkins_EC2-Master-instance.tmplt.json`: Used to launch and configure the EC2 that will host the Jenkins Master service
+* `make_jenkins_EC2-Master-autoscale.tmplt.json`: Used to launch and configure an AutoScaling-managed EC2 that will host the Jenkins Master service [Note: not extensively tested]
+* `make_jenkins_ELBv1-pub-autoscale.tmplt.json`: Used to create and configure the AWS "Classic" Elastic LoadBalancer that proxies user-requests to the privately-hosted EC2 that hosts the Jenkins Master service
+* `make_jenkins_infra.tmplt.json`: Used to create and configure the native AWS elements that support the Jenkins-hosting EC2 instance (excluding the Elastic LoadBalancer)
+
+
+ 
+#### Indirectly-Used Templates
+
+The following are categorized as "indirectly-used" because they are launched as children of the `make_jenkins_infra.tmplt.json` template described in the previous section:
+
+* `make_jenkins_IAM-role.tmplt.json`: Used to create an instance-role to apply to the Jenkins-hosting EC2. Allows the EC2 to access its backup-bucket and other (optional) AWS services.
+* `make_jenkins_S3-bucket.tmplt.json`: Used to create the S3 bucket used to host service backups and auto-recovery data
+* `make_jenkins_SGs.tmplt.json`: Used to create the AWS VPC's network security-groups.
+
+### Instance-Level Automation
+
+In addition to cloud-layer automation, there is instance-layer automation. This automation is fetched and invoked by way of `cfn-init` components within the `make_jenkins_EC2-Master-instance.tmplt.json` (or `make_jenkins_EC2-Master-autoscale.tmplt.json`) CloudFormation template(s).
+
+* `jenkins_osprep.sh`: This script does basic preparation of a generic, Enterprise Linux 7 instance &mdash; things like OS-hardening, adding exceptions to the host-based firewall and taking care of (initial) RPM dependencies.
+* `jenkins_appinstall.sh`: This script takes care of fetching, installing and configuring the Jenkins binaries and related tasks.
+
+The above _could_ have been built into a single script. However, it was anticipated that some users of this automation-set may prefer to substitute their own secondary-provisioning services &mdash; Ansible, SaltStack, Puppet, etc. &mdash; for these types of tasks. Automation users with such a preference can reference an appropriate substitute-script in their invocation of the `make_jenkins_EC2-Master-instance.tmplt.json` (or `make_jenkins_EC2-Master-autoscale.tmplt.json`) CloudFormation template(s).
+
+## Deployment/Workflow
+
+As alluded to above, automation takes care of cloud- and instance-level provisioning tasks. These are taken care of by a mix of CloudFormation templates and instance-level scripts. This automation takes care of, in to main sequences:
+
+* Provisioning cloud-level resources
+* Provisioning instance-level resources
+
+Further, cloud-level resources will be configured prior-to &mdash; and in service of &mdash; the instance-level resource-provisioning.
+
+It will be necessary to upload all of the template files and instance-level automation-scripts into an S3 bucket. A private bucket can be used, however, it will be necessary to make the instance-level automation-scripts anonymously-accessible. The templates only need be accessible from the CloudFormation subsystem (a default S3 bucket created within the same account as CloudFormation actions are executed should satisfy this need).
+
+### Cloud Provisioning
+
+As noted above, the cloud-level tasks consist of directly- and indirectly-deployed CloudFormation templates. This design was chosen in recognition that some automation-users' organizations may break up permissions in a way that doesn't allow a user to execute all of the sub-tasks within a single IAM user's &mdash; or role's &mdash; scope.
+
+Each of the templates noted as indirectly-deployed _can_ be directly deployed. However, this is not generally recommended as it increases the complexity of taskings required of the automation-user. Such usage is out of the scope of this document.
+
+Note: If using the indirectly-deployed templates directly, omit use of the `make_jenkins_infra.tmplt.json` template.
+
+The first step is to launch the `make_jenkins_infra.tmplt.json` template. This can be done through either the web UI or the AWS CLI utility.
+
+* Use by way of the web UI should be generally self-explanatory to those familiar with launching templates via that method.
+* When using the AWS CLI, it is recommended to pass all template parameters by way of a parameters-file. The parameters-file must contain a parameter-definition for any parameter that does not have a default value or for which an override is desired. See the [example file](infrastructure.parameters).
+
+After the "infra" template has been launched, monitor its progress:
+* Correct any errors encountered &mdash; usually bad parameters or permission errors on dependencies &mdash; and re-launch as necessary.
+* After Stack successfully completes, move on to deploying the `make_jenkins_ELBv1-pub-autoscale.tmplt.json` template.
+
+As with the `make_jenkins_infra.tmplt.json`, the `make_jenkins_ELBv1-pub-autoscale.tmplt.json` template can be deployed through either the web UI or the AWS CLI utility. Similarly, if using the AWS CLI, it is recommended to pass all template parameters by way of a parameters-file. See the [example file](ELBv1.parameters).
+
+
+After the "ELBv1" template has been launched, monitor its progress:
+* Correct any errors encountered &mdash; usually bad parameters or permission errors on dependencies &mdash; and re-launch as necessary.
+* After Stack successfully completes, move on to deploying the Instance Provisioning section.
+
+### Instance Provisioning
+
+Launch the `make_jenkins_EC2-Master-instance.tmplt.json` template. As with the previously-launched templates, launching the `make_jenkins_EC2-Master-instance.tmplt.json` template can be done through either the web UI or the AWS CLI utility. Similarly, use of a parameters-file is recommended.  See the [example file](ec2.parameters).

--- a/docs/Deployment-Upgrade_InPlace-OS.md
+++ b/docs/Deployment-Upgrade_InPlace-OS.md
@@ -1,0 +1,66 @@
+# Upgrading The Jenkins Service - Master Node
+
+## Purpose
+
+This document is intended to walk the automation-user through the process of upgrading an Jenkins-hosting EC2 instance from a previous, template-based deployment.
+
+This procedure is essentially the same as that used for doing an ["in-place" upgrade of the Jenkins Service](Deployment-Upgrade_InPlace-Service.md) - minus changing the version of the Jenkins service that is deployed.
+
+## Caveats
+
+While this procedure has proven to be fairly reliable, it _does_ depend on success of the to-be-upgraded instance's backups. It is best to verify that the available sync-backups are good before initiating this procedure. Overall, this process should be vetted and run under any relevant site-local policies regarding upgrades.
+
+## Dependencies
+
+In order to use these templates, the following things will be necessary:
+
+* Access to an AWS account
+* An IAM user or role with (at least) enough permissions to:
+    * Modify classic Elastic LoadBalancers (ELBs)
+    * Create/Modify CloudWatch Logs log-groups (Optional: only required if deploying to a region that supports the use of the CloudWatch Logs service and wishing to take advantage of same)
+    * Create/Modify DNS records in Route53 (Optional: only required if deploying to a region that supports Route53 and use of Route53 DNS service is desired)
+* Access to a computer that has a modern git client
+* Access to a computer that has Python installed (and is pip-enabled)
+* Access to a computer that has a modern web browser
+* Access to a computer that has the AWS CLI installed or _installable_ (e.g., `pip install awscli`)
+* Ability to configure the AWS CLI to use the previously-described IAM user or role
+
+## Assumptions/Dependencies
+
+* The automation user has a verified backup of the running configuration (or the ability to do so immediately prior to attempting th
+e upgrade)
+* The Jenkins-hosting EC2 instance was deployed using the `make_jenkins_EC2-Master-instance.tmplt.json` template
+* The "JenkinsRpmName" parameter-value was specified as a version-pinned value in the previous deployment
+* Automation user has sufficient privileges to execute an instance-replacing CloudFormation stack-update action
+
+## Workflow Description
+
+While this task can, notionally, be done through both the CloudFormation web UI and the AWS CLI, only procedures for use with the we
+b UI have been validated.
+
+### Update Via Web UI
+
+1. Login to the CloudFormation web console
+1. Locate the previously-deployed stack
+1. Select the  previously-deployed stack
+1. Select the "Update Stack" option from the `Action` button/menu
+1. Select "Use current template" from the "Select Template" page.
+1. Change the value of the "AmiId" parameter to the AMI you wish to update to
+1. Note: Other parameters may also be modified. However, doing so is out of scope for this document.
+1. Click on the "Next" button to get to the "Options" page
+1. Click on the "Next" button to get to the "Review" page
+1. Validate all values are as desired. Note that the instance should be shown for replacement in the "Preview your changes" section.
+1. Click on the "Update" button to commence the process.
+1. Track the update process
+    * If the update succeeds, the previous instance will be terminated
+    * If the update fails, the new instance will be terminated. If &mdash; per the caveats section &mdash; the previous instance wa
+stopped, it will need to be restarted for services to resume.
+1. Login to the Jenkins service and verify that previous functionality is present on the replacement node.
+
+### Update Via AWS CLI
+
+**TBD**
+
+## "Under the Covers"
+
+When the stack-update executes, a new EC2 instance is launched in parallel. The application installation/configuration scripts will attempt to find a recent sync-backup in the associated S3 bucket's `Backups/sync/` folder. If it finds a good backup, it will attempt to auto-recover from that data as part of the deployment processes. Once complete, the original instance will be terminated and a new, upgraded instance should be online with all of the data of the prior instance's last sync-backup.

--- a/docs/Deployment-Upgrade_InPlace-Service.md
+++ b/docs/Deployment-Upgrade_InPlace-Service.md
@@ -1,0 +1,67 @@
+# Upgrading The Jenkins Service - Master Node
+
+## Purpose
+
+This document is intended to walk the automation-user through the process of upgrading a Jenkins service from a previous, template-based deployment.
+
+## Caveats
+
+While this procedure has proven to be fairly reliable, it _does_ depend on success of the to-be-upgraded instance's backups. It is best to verify that the available sync-backups are good before initiating this procedure. Overall, this process should be vetted and run under any relevant site-local policies regarding upgrades.
+
+## Dependencies
+
+In order to use these templates, the following things will be necessary:
+
+* Access to an AWS account
+* An IAM user or role with (at least) enough permissions to:
+    * Modify classic Elastic LoadBalancers (ELBs)
+    * Create/Modify CloudWatch Logs log-groups (Optional: only required if deploying to a region that supports the use of the CloudWatch Logs service and wishing to take advantage of same)
+    * Create/Modify DNS records in Route53 (Optional: only required if deploying to a region that supports Route53 and use of Route53 DNS service is desired)
+* Access to a computer that has a modern git client
+* Access to a computer that has Python installed (and is pip-enabled)
+* Access to a computer that has a modern web browser
+* Access to a computer that has the AWS CLI installed or _installable_ (e.g., `pip install awscli`)
+* Ability to configure the AWS CLI to use the previously-described IAM user or role
+
+## Assumptions/Dependencies
+
+* The automation user has a verified backup of the running configuration (or the ability to do so immediately prior to attempting th
+e upgrade)
+* The Jenkins-hosting EC2 instance was deployed using the `make_jenkins_EC2-Master-instance.tmplt.json` template
+* The "JenkinsRpmName" parameter-value was specified as a version-pinned value in the previous deployment
+* Automation user has sufficient privileges to execute an instance-replacing CloudFormation stack-update action
+
+## Workflow Description
+
+While this task can, notionally, be done through both the CloudFormation web UI and the AWS CLI, only procedures for use with the we
+b UI have been validated.
+
+### Update Via Web UI
+
+1. Login to the CloudFormation web console
+1. Locate the previously-deployed stack
+1. Select the  previously-deployed stack
+1. Select the "Update Stack" option from the `Action` button/menu
+1. Select "Use current template" from the "Select Template" page.
+1. Change the value of the "JenkinsRpmName" parameter to the Jenkins RPM you wish to upgrade to.
+1. Force a redeployment by:
+   * Changing the value of the "AmiId" parameter to the AMI you wish to update to; and/or
+   * Changing the value of the "SubnetId" to one of the other subnets in the VPC (if VPC has public and private subnets, change to another subnet of the same type).
+1. Note: Other parameters may also be modified. However, doing so is out of scope for this document.
+1. Click on the "Next" button to get to the "Options" page
+1. Click on the "Next" button to get to the "Review" page
+1. Validate all values are as desired. Note that the instance should be shown for replacement in the "Preview your changes" section.
+1. Click on the "Update" button to commence the process.
+1. Track the update process
+    * If the update succeeds, the previous instance will be terminated
+    * If the update fails, the new instance will be terminated. If &mdash; per the caveats section &mdash; the previous instance wa
+stopped, it will need to be restarted for services to resume.
+1. Login to the Jenkins service and verify that previous functionality is present on the replacement node.
+
+### Update Via AWS CLI
+
+**TBD**
+
+## "Under the Covers"
+
+When the stack-update executes, a new EC2 instance is launched in parallel. The application installation/configuration scripts will attempt to find a recent sync-backup in the associated S3 bucket's `Backups/sync/` folder. If it finds a good backup, it will attempt to auto-recover from that data as part of the deployment processes. Once complete, the original instance will be terminated and a new, upgraded instance should be online with all of the data of the prior instance's last sync-backup.

--- a/docs/Deployment-Upgrade_Parallel.md
+++ b/docs/Deployment-Upgrade_Parallel.md
@@ -1,0 +1,66 @@
+# Deploying a Parallel, Upgraded Jenkins Service - Master Node
+
+## Purpose
+
+This document is intended to walk the automation-user through the process of deploying a paralle, upgraded deployment of an existing Jenkis service using templates included in this project.
+
+## Dependencies
+
+Because a parallel-deployment is essentially the same as for a wholly-new deployment, The following dependencies are the same as those for a [brand-new deployment](Deployment-Fresh.md#dependencies):
+
+* Access to an AWS account
+* An IAM user or role with (at least) enough permissions to:
+    * Create EC2 network security groups
+    * Create S3 buckets
+    * Create classic Elastic LoadBalancers (ELBs)
+    * Create IAM instance-roles and policies
+    * Create RDS databases
+    * Create EFS shares (Optional: only required if deploying to an EFS-supporting region and choosing to use EFS for persistent storage)
+    * Create CloudWatch Logs log-groups (Optional: only required if deploying to a region that supports the use of the CloudWatch Logs service and wishing to take advantage of same)
+    * Create new DNS records in Route53 (Optional: only required if deploying to a region that supports Route53 and use of Route53 DNS service is desired)
+* Access to a computer that has a modern git client
+* Access to a computer that has Python installed (and is pip-enabled)
+* Access to a computer that has a modern web browser
+* Access to a computer that has the AWS CLI installed or _installable_ (e.g., `pip install awscli`)
+* Ability to configure the AWS CLI to use the previously-described IAM user or role
+* Availability of a known-good, _recent_ backup of the to-be-replaced Jenkins service.
+
+## Automation Elements
+
+See section-contents in [brand-new deployment](Deployment-Fresh.md#automation-elements)
+
+### Cloud-Level Automation
+
+See section-contents in [brand-new deployment](Deployment-Fresh.md#cloud-level-automation)
+
+#### Directly-Used Templates
+
+See section-contents in [brand-new deployment](Deployment-Fresh.md#directly-used-templates)
+ 
+#### Indirectly-Used Templates
+
+See section-contents in [brand-new deployment](Deployment-Fresh.md#indirectly-used-templates)
+
+### Instance-Level Automation
+
+See section-contents in [brand-new deployment](Deployment-Fresh.md#instance-level-automation)
+
+## Deployment/Workflow
+
+The "upgrade" process follows a generic workflow of:
+
+1. Deploy new "infrastructure" stack-set &mdash; See _Wholly-New Jenkins Service_'s [Cloud Provisioning](Deployment-Fresh.md#cloud-provisioning) section.
+1. Deploy new ELB stack &mdash; See _Wholly-New Jenkins Service_'s [Cloud Provisioning](Deployment-Fresh.md#cloud-provisioning) section.
+1. Duplicate backup-data from prior Jenkins service's backup-bucket to the new backup-bucket (created in first step) &mdash; see method-description ([below](Deployment-Upgrade_Parallel.md#bucket-to-bucket-data-copy))
+1. Deploy new EC2 stack &mdash; See _Wholly-New Jenkins Service_'s [Instance Provisioning](Deployment-Fresh.md#instance-provisioning) section.
+
+## Bucket-to-Bucket Data-Copy
+
+It will be necessary to execute a third-party copy of data from the source bucket to the destination bucket. This is most-easily done using the AWS CLI &mdash; it is assumed that the CLI has permissions to both the source and destination buckets. (see notes in the dependencies section about "Access to a computer...").
+
+1. Determine the name of the source bucket and path to most-recent backup file
+2. Determine the name of the destination bucket
+3. Execute a bucket to bucket copy operation similar to: 
+    ~~~~
+    aws s3 cp s3://<SOURCE_BUCKET>/Backups/sync/<LATEST_SYNC_FILE>.tar s3://<DESTINATION_BUCKET>/Backups/sync/
+    ~~~~

--- a/docs/ELBv1.parameters
+++ b/docs/ELBv1.parameters
@@ -1,0 +1,38 @@
+[
+    {
+        "ParameterKey": "BackendTimeout",
+        "ParameterValue": "<TIMEOUT_IN_SECONDS>" <-- Recommend value >= 600
+    },
+    {
+        "ParameterKey": "HaSubnets",
+        "ParameterValue": "<USER_FACING_VPC_SUBNETS>
+    },
+    {
+        "ParameterKey": "JenkinsAgentPort",
+        "ParameterValue": "<PORT_NUMBER_USED_BY_JNLP_CLIENTS>"
+    },
+    {
+        "ParameterKey": "JenkinsListenerCert",
+        "ParameterValue": "<ACM_CERT_ID || IAM_SERVER_CERTIFICATE_NAME>"
+    },
+    {
+        "ParameterKey": "JenkinsListenPort",
+        "ParameterValue": "<USER_FACING_LISTENING_PORT_NUMBER>"
+    },
+    {
+        "ParameterKey": "JenkinsPassesSsh",
+        "ParameterValue": "<BOOLEAN>"
+    },
+    {
+        "ParameterKey": "JenkinsServicePort",
+        "ParameterValue": "<PRIVATE_LISTENING_PORT_NUMBER>"
+    },
+    {
+        "ParameterKey": "ProxyPrettyName",
+        "ParameterValue": "<MAY_BE_NULL>"
+    },
+    {
+        "ParameterKey": "SecurityGroupIds",
+        "ParameterValue": "<APPLICATION_SECURITY_GROUP_ID>"
+    }
+]

--- a/docs/ec2.parameters
+++ b/docs/ec2.parameters
@@ -1,0 +1,130 @@
+[
+    {
+        "ParameterKey": "AdminPubkeyURL",
+        "ParameterValue": "https://s3.<AWS_REGION><AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/<GROUP_KEYFILE_NAME>"
+    },
+    {
+        "ParameterKey": "AmiId",
+        "ParameterValue": "<AMI_ID>"
+    },
+    {
+        "ParameterKey": "AppVolumeDevice",
+        "ParameterValue": "<BOOLEAN>"
+    },
+    {
+        "ParameterKey": "AppVolumeMountPath",
+        "ParameterValue": "<FULLY_QUALIFIED_PATH>"  <-- Usually "/var/lib/jenkins"
+    },
+    {
+        "ParameterKey": "AppVolumeSize",
+        "ParameterValue": "<SIZE_TO_MAKE_JENKINS_HOME>"
+    },
+    {
+        "ParameterKey": "AppVolumeType",
+        "ParameterValue": "< "gp2 || io1 || sc1 || st1 || standard>"
+    },
+    {
+        "ParameterKey": "BackupBucket",
+        "ParameterValue": "<BUCKET_NAME_FROM_S3_STACK_OUTPUT>"
+    },
+    {
+        "ParameterKey": "BackupCronURL",
+        "ParameterValue": "https://s3.<AWS_REGION><AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/jenkins_backups.cron"
+    },
+    {
+        "ParameterKey": "BackupFolder",
+        "ParameterValue": "Backups"
+    },
+    {
+        "ParameterKey": "CfnEndpointUrl",
+        "ParameterValue": "https://cloudformation.<AWS_REGION>.<AWS_URL_SUFFIX>"
+    },
+    {
+        "ParameterKey": "DnsSuffix",
+        "ParameterValue": "<DNS_DOMAIN_OF_SERVICE>"
+    },
+    {
+        "ParameterKey": "EpelRepo",
+        "ParameterValue": "<NAME_OF_EPEL_REPO>"  <-- Usually just "epel"
+    },
+    {
+        "ParameterKey": "InstanceRole",
+        "ParameterValue": "<IAM_ROLE_NAME_FROM_IAM_STACK_OUTPUT>"
+    },
+    {
+        "ParameterKey": "InstanceType",
+        "ParameterValue": "<VALID_AWS_INSTANCE_TYPE>"
+    },
+    {
+        "ParameterKey": "JenkinsAppinstallScriptUrl",
+        "ParameterValue": "https://s3.<AWS_REGION><AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/jenkins_appinstall.sh"
+    },
+    {
+        "ParameterKey": "JenkinsOsPrepScriptUrl",
+        "ParameterValue": "https://s3.<AWS_REGION><AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/jenkins_osprep.sh"
+    },
+    {
+        "ParameterKey": "JenkinsRepoKeyURL",
+        "ParameterValue": "<URL_OF_RPM_SIGNING-KEY>"
+    },
+    {
+        "ParameterKey": "JenkinsRepoURL",
+        "ParameterValue": "<URL_OF_YUM_REPO>"
+    },
+    {
+        "ParameterKey": "JenkinsRpmName",
+        "ParameterValue": "<NAME_OR_RPM>"  <-- Include "-X.Y.Z" to pin to a specific version
+    },
+    {
+        "ParameterKey": "KeyPairName",
+        "ParameterValue": "<MAY_BE_NULL>"
+    },
+    {
+        "ParameterKey": "NoPublicIp",
+        "ParameterValue": "<BOOLEAN>"
+    },
+    {
+        "ParameterKey": "NoReboot",
+        "ParameterValue": "<BOOLEAN>"
+    },
+    {
+        "ParameterKey": "NoUpdates",
+        "ParameterValue": "<BOOLEAN>"
+    },
+    {
+        "ParameterKey": "PipIndexFips",
+        "ParameterValue": "<URL_OF_PYPI_INDEX>"
+    },
+    {
+        "ParameterKey": "PipRpm",
+        "ParameterValue": "python2-pip"
+    },
+    {
+        "ParameterKey": "ProvisionUser",
+        "ParameterValue": "<NAME_TO_ASSIGN_TO_EC2_DEFAULT_USER_ACCOUNT>"
+    },
+    {
+        "ParameterKey": "PyStache",
+        "ParameterValue": "pystache"
+    },
+    {
+        "ParameterKey": "SecurityGroupIds",
+        "ParameterValue": "<SECURITY_GROUP_ID_FROM_SG_STACK_OUTPUT>"
+    },
+    {
+        "ParameterKey": "ServerHostname",
+        "ParameterValue": "<NODENAME_TO_ASSIGN_TO_INSTANCE>"
+    },
+    {
+        "ParameterKey": "SubnetIds",
+        "ParameterValue": "<SUBNET_TO_DEPLOY_INSTANCE_INTO>"
+    },
+    {
+        "ParameterKey": "WatchmakerConfig",
+        "ParameterValue": "<MAY_BE_NULL>"
+    },
+    {
+        "ParameterKey": "WatchmakerEnvironment",
+        "ParameterValue": "<(null) || dev || test || prod>"
+    }
+]

--- a/docs/infrastructure.parameters
+++ b/docs/infrastructure.parameters
@@ -1,0 +1,34 @@
+[
+    {
+        "ParameterKey": "BucketTemplate",
+        "ParameterValue": "https://s3.<AWS_REGION>.<AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/make_jenkins_S3-bucket.tmplt.json"
+    },
+    {
+        "ParameterKey": "IamRoleTemplate",
+        "ParameterValue": "https://s3.<AWS_REGION>.<AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/make_jenkins_IAM-role.tmplt.json"
+    },
+    {
+        "ParameterKey": "JenkinsAgentPort",
+        "ParameterValue": "<PORT_NUMBER_USED_BY_JNLP_CLIENTS>"
+    },
+    {
+        "ParameterKey": "JenkinsBackupBucket",
+        "ParameterValue": "<MAY_BE_NULL>"
+    },
+    {
+        "ParameterKey": "RolePrefix",
+        "ParameterValue": "<MAY_BE_NULL>"
+    },
+    {
+        "ParameterKey": "SecurityGroupTemplate",
+        "ParameterValue": "https://s3.<AWS_REGION>.<AWS_URL_SUFFIX>/<BUCKET_NAME>/<OBJECT_PATH-KEY>/make_jenkins_SGs.tmplt.json"
+    },
+    {
+        "ParameterKey": "ServiceTld",
+        "ParameterValue": "<AWS_URL_SUFFIX>"
+    },
+    {
+        "ParameterKey": "TargetVPC",
+        "ParameterValue": "<DEPLOYMENT_VPC_ID>"
+    }
+]


### PR DESCRIPTION
#### Description:

Add deployment-guidance for using the more-consolidated parent/infrastructure templates

#### Rationale:

Prior documentation only covered template-at-a-time deployment. With subsequent addition of "infrastructure" templates, needed to add associated guidance.